### PR TITLE
Enhancements for Announcements.  preview announcement and show announcement history. 

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/controller/PreviewAnnouncementController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/PreviewAnnouncementController.java
@@ -1,0 +1,63 @@
+package org.jasig.portlet.announcements.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.jasig.portlet.announcements.UnauthorizedException;
+import org.jasig.portlet.announcements.model.Announcement;
+import org.jasig.portlet.announcements.model.Topic;
+import org.jasig.portlet.announcements.service.IAnnouncementService;
+import org.jasig.portlet.announcements.service.UserPermissionChecker;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.mvc.AbstractController;
+
+/**
+ * @author Jen Bourey, jbourey@unicon.net
+ * @version $Revision$
+ */
+public class PreviewAnnouncementController extends AbstractController {
+
+    private IAnnouncementService announcementService = null;
+    private Boolean includeJQuery;
+    
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.web.portlet.mvc.AbstractController#handleRenderRequestInternal(javax.portlet.RenderRequest, javax.portlet.RenderResponse)
+     */
+    @Override
+    protected ModelAndView handleRenderRequestInternal(RenderRequest request,
+            RenderResponse response) throws Exception {
+
+        Map<String, Object> model = new HashMap<String, Object>();
+        
+        Long annId = Long.parseLong(request.getParameter("annId"));
+        Announcement ann = announcementService.getAnnouncement(annId);
+        
+        Topic topic = ann.getParent();
+        
+        if (!UserPermissionChecker.inRoleForTopic(request, "authors", topic) &&
+                !UserPermissionChecker.inRoleForTopic(request, "moderators", topic) &&
+                !UserPermissionChecker.inRoleForTopic(request, "admins", topic)) {
+            throw new UnauthorizedException("You do not have access to this topic!");
+        }
+
+        model.put("announcement", ann);
+        model.put("user", new UserPermissionChecker(request, topic));
+        model.put("includeJQuery", includeJQuery);
+        
+        return new ModelAndView("previewAnnouncement", model);
+
+    }
+
+    public void setAnnouncementService(IAnnouncementService announcementService) {
+        this.announcementService = announcementService;
+    }
+    
+    public void setIncludeJQuery(Boolean includeJQuery) {
+        this.includeJQuery = includeJQuery;
+    }
+
+}

--- a/src/main/java/org/jasig/portlet/announcements/controller/ShowHistoryController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/ShowHistoryController.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.announcements.controller;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.apache.log4j.Logger;
+import org.jasig.portlet.announcements.UnauthorizedException;
+import org.jasig.portlet.announcements.model.Announcement;
+import org.jasig.portlet.announcements.model.Topic;
+import org.jasig.portlet.announcements.service.IAnnouncementService;
+import org.jasig.portlet.announcements.service.UserPermissionChecker;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.mvc.AbstractController;
+
+/**
+ * @author Erik A. Olsson (eolsson@uci.edu)
+ * 
+ *         $LastChangedBy: billbrown $ $LastChangedDate: 2010-12-07 15:39:53
+ *         -0600 (Tue, 12 Jan 2010) $
+ */
+public class ShowHistoryController extends AbstractController {
+
+	private IAnnouncementService announcementService;
+	private Boolean includeJQuery;
+	private static final org.apache.log4j.Logger logger = Logger
+			.getLogger(ShowHistoryController.class);
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.web.portlet.mvc.AbstractController#
+	 * handleRenderRequestInternal(javax.portlet.RenderRequest,
+	 * javax.portlet.RenderResponse)
+	 */
+	@Override
+	protected ModelAndView handleRenderRequestInternal(RenderRequest request,
+			RenderResponse response) throws Exception {
+
+		HashMap<String, Object> mav = new HashMap<String, Object>();
+
+		String topicId = (String) request.getParameter("topicId");
+		Topic topic = announcementService.getTopic(Long.parseLong(topicId));
+
+		if (!UserPermissionChecker.inRoleForTopic(request, "authors", topic)
+				&& !UserPermissionChecker.inRoleForTopic(request, "moderators",
+						topic)
+				&& !UserPermissionChecker.inRoleForTopic(request, "admins",
+						topic)) {
+			throw new UnauthorizedException(
+					"You do not have access to this topic!");
+		}
+
+		Set<Announcement> annSet = topic.getAnnouncements();
+		List<Announcement> annList = new ArrayList<Announcement>();
+		// only add expired announcements to this list.
+		for (Announcement ann : annSet) {
+			if (ann.getEndDisplay().compareTo(Calendar.getInstance().getTime()) < 0) {
+				annList.add(ann);
+			}
+		}
+
+		if (annList != null) {
+			Collections.sort(annList);
+		}
+
+		logger.info("number of announcements: " + annList.size());
+
+		mav.put("user", new UserPermissionChecker(request, topic));
+		mav.put("topic", topic);
+		mav.put("announcements", annList);
+		mav.put("now", new Date());
+		mav.put("includeJQuery", includeJQuery);
+
+		return new ModelAndView("showHistory", mav);
+	}
+
+	/**
+	 * @param announcementService
+	 *            the announcementService to set
+	 */
+	public void setAnnouncementService(IAnnouncementService announcementService) {
+		this.announcementService = announcementService;
+	}
+
+	public void setIncludeJQuery(Boolean includeJQuery) {
+		this.includeJQuery = includeJQuery;
+	}
+
+}

--- a/src/main/java/org/jasig/portlet/announcements/controller/ShowTopicController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/ShowTopicController.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.announcements.controller;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.jasig.portlet.announcements.UnauthorizedException;
+import org.jasig.portlet.announcements.model.Announcement;
+import org.jasig.portlet.announcements.model.Topic;
+import org.jasig.portlet.announcements.service.IAnnouncementService;
+import org.jasig.portlet.announcements.service.UserPermissionChecker;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.mvc.AbstractController;
+
+/**
+ * @author Erik A. Olsson (eolsson@uci.edu)
+ * 
+ *         $LastChangedBy: eolsson $ $LastChangedDate: 2010-01-12 15:39:53 -0600
+ *         (Tue, 12 Jan 2010) $
+ */
+public class ShowTopicController extends AbstractController {
+
+	private IAnnouncementService announcementService;
+	private Boolean includeJQuery;
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.web.portlet.mvc.AbstractController#
+	 * handleRenderRequestInternal(javax.portlet.RenderRequest,
+	 * javax.portlet.RenderResponse)
+	 */
+	@Override
+	protected ModelAndView handleRenderRequestInternal(RenderRequest request,
+			RenderResponse response) throws Exception {
+
+		HashMap<String, Object> mav = new HashMap<String, Object>();
+
+		String topicId = (String) request.getParameter("topicId");
+		Topic topic = announcementService.getTopic(Long.parseLong(topicId));
+
+		if (!UserPermissionChecker.inRoleForTopic(request, "authors", topic)
+				&& !UserPermissionChecker.inRoleForTopic(request, "moderators",
+						topic)
+				&& !UserPermissionChecker.inRoleForTopic(request, "admins",
+						topic)) {
+			throw new UnauthorizedException(
+					"You do not have access to this topic!");
+		}
+
+		Set<Announcement> annSet = topic.getAnnouncements();
+		List<Announcement> annList = new ArrayList<Announcement>();
+		// don't add topics that are expired to be in the list of those
+		// displayed.
+		for (Announcement ann : annSet) {
+			if (ann.getEndDisplay().compareTo(Calendar.getInstance().getTime()) > 0) {
+				annList.add(ann);
+			}
+		}
+
+		if (annSet.size() < 1)
+			annList = null;
+
+		if (annList != null) {
+			Collections.sort(annList);
+		}
+
+		mav.put("user", new UserPermissionChecker(request, topic));
+		mav.put("topic", topic);
+		mav.put("announcements", annList);
+		mav.put("now", new Date());
+		mav.put("includeJQuery", includeJQuery);
+
+		return new ModelAndView("showTopic", mav);
+	}
+
+	/**
+	 * @param announcementService
+	 *            the announcementService to set
+	 */
+	public void setAnnouncementService(IAnnouncementService announcementService) {
+		this.announcementService = announcementService;
+	}
+
+	public void setIncludeJQuery(Boolean includeJQuery) {
+		this.includeJQuery = includeJQuery;
+	}
+
+}

--- a/src/main/java/org/jasig/portlet/announcements/service/AnnouncementCleanupThread.java
+++ b/src/main/java/org/jasig/portlet/announcements/service/AnnouncementCleanupThread.java
@@ -77,7 +77,9 @@ public class AnnouncementCleanupThread extends Thread {
 				(firstCheck || System.currentTimeMillis() > (lastCheckTime + maxCheckIntervalMillis))) {
 				
 				log.info("Going to delete old announcements at "+now.toString());
-				announcementService.deleteAnnouncementsPastCurrentTime();
+				//UOC Customization.
+				//we no longer want to auto delete events. 
+				//announcementService.deleteAnnouncementsPastCurrentTime();
 				lastCheckTime = System.currentTimeMillis();
 				firstCheck = false;
 			}

--- a/src/main/java/org/jasig/portlet/announcements/service/UserPermissionChecker.java
+++ b/src/main/java/org/jasig/portlet/announcements/service/UserPermissionChecker.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import javax.portlet.PortletRequest;
 
+import org.apache.log4j.Logger;
 import org.jasig.portlet.announcements.model.Topic;
 
 
@@ -45,7 +46,10 @@ public class UserPermissionChecker {
 	public String userName;
 	
 	private static final String ADMIN_ROLE_NAME = "Portal_Administrators";
-	
+
+	private static final org.apache.log4j.Logger logger = Logger
+			.getLogger(UserPermissionChecker.class);
+
 	/**
 	 * 
 	 * @param request
@@ -78,6 +82,15 @@ public class UserPermissionChecker {
 	}
 	
 	public static boolean isPortalAdmin(PortletRequest request) {
+
+		if (logger.isTraceEnabled()) {
+			logger.trace("isPortalAdmin "
+					+ request.getRemoteUser()
+					+ "? "
+					+ request
+							.isUserInRole(UserPermissionChecker.ADMIN_ROLE_NAME));
+		}
+
 		return request.isUserInRole(UserPermissionChecker.ADMIN_ROLE_NAME);
 	}
 	
@@ -102,12 +115,25 @@ public class UserPermissionChecker {
 		}
 		
 		Set<String> group = topic.getGroup(role);
-		for (String groupMember: group) {
+
+		for (String groupMember : group) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("is " + user + " a member of " + groupMember
+						+ " for '" + topic.getTitle() + "'? "
+						+ request.isUserInRole(groupMember));
+			}
 			if (request.isUserInRole(groupMember)) {
 				return true;
 			}
 			if (groupMember.startsWith("USER.")) {
 				String p[] = groupMember.split("\\.");
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("does " + user + " match " + p[1] + " for '"
+							+ topic.getTitle() + "'? "
+							+ p[1].equalsIgnoreCase(user));
+				}
+
 				if (p[1].equalsIgnoreCase(user)) {
 					return true;
 				}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -73,6 +73,13 @@ display.link.prev=Previous
 display.link.next=Next
 display.link.placeholder=External link
 display.no.announcements=There are no announcements at this time.
+display.link.history=View Previous...
+
+## displayHistory ##
+display.header.start=Start Date
+display.header.end=End Date
+display.back=Back to Home
+displayFullHistory.back=Back to announcement history
 
 ## displayFullAnnouncement.jsp ##
 displayFull.displayBegin=Published
@@ -105,10 +112,12 @@ show.showing=Showing
 show.pending=Pending
 show.expired=Expired
 show.viewedit=View/Edit
+show.edit=Edit
 show.delete=Delete
 show.publish=Publish
 show.unpublish=Take Down
 show.addAnn=Add Announcement
 show.header.permissions=Permissions for
 show.permissions.edit=Edit
+show.history=View History
 

--- a/src/main/webapp/WEB-INF/context/portlet/announcementsAdmin.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/announcementsAdmin.xml
@@ -64,7 +64,9 @@
     <bean id="adminTopicController" class="org.jasig.portlet.announcements.controller.AdminTopicController"/>
     <bean id="adminAnnouncementController" class="org.jasig.portlet.announcements.controller.AdminAnnouncementController"/>
     <bean id="adminRoleSetController" class="org.jasig.portlet.announcements.controller.AdminRoleSetController"/>
-
+    <bean id="previewAnnouncementController" class="org.jasig.portlet.announcements.controller.PreviewAnnouncementController"/>
+	<bean id="showTopicController" class="org.jasig.portlet.announcements.controller.ShowTopicController"/>
+    <bean id="showHistoryController" class="org.jasig.portlet.announcements.controller.ShowHistoryController"/>
    
     <bean id="exceptionHandler" parent="defaultExceptionHandlerTemplate"/>
     

--- a/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
@@ -39,10 +39,10 @@
 
 <portlet:actionURL var="actionUrl">
 	<portlet:param name="action" value="addAnnouncement"/>
-	<portlet:param name="topicId" value="${announcement.parent.id}"/>
+	<portlet:param name="topicId" value="${topicId}"/>
 </portlet:actionURL>
 
-<div class="portlet-section-header"><spring:message code="addAnnouncement.header"/> <c:out value="${announcement.parent.title}"/></div>
+<div class="portlet-section-header"><spring:message code="addAnnouncement.header"/> <c:out value="${topicTitle}"/></div>
 
 <form:form commandName="announcement" method="post" action="${actionUrl}">
 <table width="100%" cellpadding="3">
@@ -61,7 +61,31 @@
 		</td>
 		<td>
 			<form:errors cssClass="portlet-msg-error" path="abstractText"/>
-			<form:textarea cssClass="portlet-form-input-field" path="abstractText" rows="2" cols="40" cssStyle="width:80%;"/>
+			<script language="javascript" type="text/javascript">
+			<!--
+			window.onload = function() { 
+				  var txts = document.getElementsByTagName('TEXTAREA') 
+
+				  for(var i = 0, l = txts.length; i < l; i++) {
+				    if(/^[0-9]+$/.test(txts[i].getAttribute("title"))) { 
+				      var func = function() { 
+				        var len = parseInt(this.getAttribute("title"), 10); 
+
+				        if(this.value.length > len) { 
+				          alert('Maximum length exceeded: ' + len); 
+				          this.value = this.value.substr(0, len); 
+				          return false; 
+				        } 
+				      }
+
+				      txts[i].onkeyup = func;
+				      txts[i].onblur = func;
+				    } 
+				  } 
+				}
+			-->
+			</script>
+			<form:textarea cssClass="portlet-form-input-field" path="abstractText" rows="2" cols="40" cssStyle="width:80%;" title="120" />
 		</td>
 	</tr>
 	<tr>
@@ -109,7 +133,7 @@
 <button type="submit" class="portlet-form-button"><spring:message code="addAnnouncement.save"/></button>
 </form:form>
 <br/>
-<a style="text-decoration:none;" href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${announcement.parent.id}"/></portlet:renderURL>">
+<a style="text-decoration:none;" href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${topicId}"/></portlet:renderURL>">
 <img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="general.backtotopic"/></a>
 &nbsp;&nbsp;
 <a style="text-decoration:none;" href="<portlet:renderURL portletMode="view" windowState="normal"></portlet:renderURL>">

--- a/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
@@ -92,6 +92,7 @@
 		<c:if test="${hasMore}">
 			<a href="<portlet:renderURL portletMode="view" windowState="normal"><portlet:param name="from" value="${from + increment}"/><portlet:param name="to" value="${to + increment}"/></portlet:renderURL>"><spring:message code="display.link.next"/> <c:out value="${increment}"/></a>
 		</c:if>
+		<a href="<portlet:renderURL portletMode="view" ><portlet:param name="action" value="displayHistory"/></portlet:renderURL>"><spring:message code="display.link.history"/></a>
 	</td>
 	<td align="right" style="font-size:0.9em; padding-top:0.5em;">
 		<c:if test="${not isGuest && not disableEdit}">

--- a/src/main/webapp/WEB-INF/jsp/displayFullAnnouncementHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayFullAnnouncementHistory.jsp
@@ -1,0 +1,32 @@
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+<%-- 
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.    
+--%>
+<div class="portlet-section-header"><c:out value="${announcement.title}"/></div>
+<p>
+<span class="portlet-section-text" style="font-size:0.8em;"><spring:message code="displayFull.displayEnd"/> <fmt:formatDate value="${announcement.endDisplay}" dateStyle="long"/></span>
+<c:if test="${not empty announcement.link}">
+	<br/>
+	<span class="portlet-section-text" style="font-size:0.8em;"><spring:message code="display.link.prefix"/> <a href="${announcement.link}"><c:out value="${announcement.link}"/></a></span>
+</c:if>
+</p>
+
+<c:out value="${announcement.message}" escapeXml="false"/>
+
+<a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"><portlet:param name="action" value="displayHistory"/></portlet:renderURL>"><img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="displayFullHistory.back"/></a>
+

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -1,0 +1,68 @@
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+
+<style type="text/css">
+.<portlet:namespace/>-row1color { padding: 5px; background-color: #eee; }
+.<portlet:namespace/>-row2color { padding: 5px; background-color: #fff; }
+.<portlet:namespace/>-emerg { padding: 5px; margin-bottom:5px; color:#c00; background-color: #fff; border: 3px solid #cc3300; }
+.<portlet:namespace/>-emerg a, .<portlet:namespace/>-emerg a:visited { text-decoration: none; color: #c00; }
+</style>
+
+<table width="100%" cellspacing="0" cellpadding="0" class="data">
+	<tr>
+		<th width="15%"><spring:message code="display.header.topic"/></th>
+		<th><spring:message code="display.header.ann"/></th>
+		<th><spring:message code="display.header.start"/></th>
+		<th><spring:message code="display.header.end"/></th>
+	</tr>
+
+	<c:forEach items="${announcements}" var="announcement" varStatus="status">
+		<tr>
+			<c:choose>
+				<c:when test="${status.index mod 2 == 0}">
+					<td align="center" width="15%" class="<portlet:namespace/>-row1color">
+						<c:out value="${announcement.parent.title}"/>
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row1color">
+						<a title="<spring:message code="display.title.fullannouncement"/>" href="<portlet:renderURL><portlet:param name="action" value="displayFullAnnouncementHistory"/><portlet:param name="announcementId" value="${announcement.id}"/></portlet:renderURL>"><c:out value="${announcement.title}"/></a>
+						<br /><c:out value="${announcement.abstractText}"/>
+						<br />
+						<c:if test="${not empty announcement.link}">
+							<span class="portlet-section-text" style="font-size:0.9em; padding-top:0.2em;"><spring:message code="display.link.prefix"/> <a href="<c:out value="${announcement.link}"/>"><c:out value="${announcement.link}"/></a></span> 
+						</c:if>			
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row1color">
+						<span class="portlet-section-text" style="font-size:0.9em;"><fmt:formatDate value="${announcement.startDisplay}" dateStyle="medium"/></span>
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row1color">
+						<span class="portlet-section-text" style="font-size:0.9em;"><fmt:formatDate value="${announcement.endDisplay}" dateStyle="medium"/></span>
+					</td>
+				</c:when>
+				<c:otherwise>
+					<td align="center" width="15%" class="<portlet:namespace/>-row2color">
+						<c:out value="${announcement.parent.title}"/>
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row2color">
+						<a title="<spring:message code="display.title.fullannouncement"/>" href="<portlet:renderURL><portlet:param name="action" value="displayFullAnnouncementHistory"/><portlet:param name="announcementId" value="${announcement.id}"/></portlet:renderURL>"><c:out value="${announcement.title}"/></a>
+						<br /><c:out value="${announcement.abstractText}"/>
+						<br />
+						<c:if test="${not empty announcement.link}">
+							<span class="portlet-section-text" style="font-size:0.9em; padding-top:0.2em;"><spring:message code="display.link.prefix"/> <a href="<c:out value="${announcement.link}"/>"><c:out value="${announcement.link}"/></a></span> 
+						</c:if>			
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row2color">
+						<span class="portlet-section-text" style="font-size:0.9em;"><fmt:formatDate value="${announcement.startDisplay}" dateStyle="medium"/></span>
+					</td>
+					<td align="center" width="15%" class="<portlet:namespace/>-row2color">
+						<span class="portlet-section-text" style="font-size:0.9em;"><fmt:formatDate value="${announcement.endDisplay}" dateStyle="medium"/></span>
+					</td>
+				</c:otherwise>
+			</c:choose>
+		</tr>
+
+	</c:forEach>
+</table>
+
+<p align="right" style="font-size:0.9em; padding-top:0.5em;">
+<a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"/>"><img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="display.back"/></a>
+</p>
+

--- a/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
@@ -1,0 +1,105 @@
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+<%-- 
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.    
+--%>
+<c:if test="${includeJQuery}">
+<script type="text/javascript" src="<c:url value="/js/jquery-1.2.3.min.js"/>"></script>
+</c:if>
+
+<style type="text/css">
+.preview-section-header { font-weight: bold; margin-top: 10px; margin-bottom: 5px; }
+.preview-section { background-color: #f3f3f3; padding: 5px; }
+</style>
+
+<div class="portlet-section-header">Preview</div>
+
+<div class="preview-section-header">Announcement List View</div>
+
+<div class="preview-section">
+    <table width="100%" cellspacing="0" cellpadding="0" class="data">
+        <tr>
+            <td align="center" width="15%" class="<portlet:namespace/>-row1color">
+                <c:out value="${announcement.parent.title}"/>
+                <c:if test="${showDate}">
+                    <br/>
+                    <span class="portlet-section-text" style="font-size:0.9em;"><fmt:formatDate value="${announcement.startDisplay}" dateStyle="medium"/></span>
+                </c:if>         
+            </td>
+            <td class="<portlet:namespace/>-row1color">
+                <a title="<spring:message code="display.title.fullannouncement"/>" href="<portlet:renderURL><portlet:param name="action" value="displayFullAnnouncement"/><portlet:param name="announcementId" value="${announcement.id}"/></portlet:renderURL>"><c:out value="${announcement.title}"/></a>
+                <br/><c:out value="${announcement.abstractText}"/>
+                <br/>
+                <c:if test="${not empty announcement.link}">
+                    <span class="portlet-section-text" style="font-size:0.9em; padding-top:0.2em;"><spring:message code="display.link.prefix"/> <a href="<c:out value="${announcement.link}"/>"><c:out value="${announcement.link}"/></a></span> 
+                </c:if>         
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div class="preview-section-header">Full Announcement View</div>
+
+<div class="preview-section">
+    <div class="portlet-section-header"><c:out value="${announcement.title}"/></div>
+    <p>
+        <span class="portlet-section-text" style="font-size:0.8em;"><spring:message code="displayFull.displayEnd"/> <fmt:formatDate value="${announcement.endDisplay}" dateStyle="long"/></span>
+        <c:if test="${not empty announcement.link}">
+            <br/>
+            <span class="portlet-section-text" style="font-size:0.8em;"><spring:message code="display.link.prefix"/> <a href="${announcement.link}"><c:out value="${announcement.link}"/></a></span>
+        </c:if>
+    </p>
+    <c:out value="${announcement.message}" escapeXml="false"/>
+</div>
+
+<br/>
+<form id="<portlet:namespace/>Form">
+    <c:if test="${ user.moderator and !announcement.published }">
+        <input class="portlet-form-button" type="submit" value="<spring:message code="show.publish"/>"/>
+    </c:if>
+    <c:if test="${ user.moderator or (user.userName == announcement.author) }">
+        <a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${announcement.id}"/></portlet:renderURL>" title="<spring:message code="show.viewedit"/>"><spring:message code="show.edit"/></a>
+    </c:if>
+</form>
+
+<p style="text-align:right">
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${ announcement.parent.id }"/></portlet:renderURL>"><img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> Back to topic</a>
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"></portlet:renderURL>"><img src="<c:url value="/icons/house.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="general.adminhome"/></a>
+</p>
+
+<script type="text/javascript">
+var <portlet:namespace/> = <portlet:namespace/> || {};
+<portlet:namespace/>.jQuery = ${ includeJQuery ? 'jQuery.noConflict(true)' : 'jQuery' };
+<portlet:namespace/>.jQuery(function(){
+   var $ = <portlet:namespace/>.jQuery;
+
+   $(document).ready(function(){
+       $("#<portlet:namespace/>Form").submit(function(){
+           $.post("<c:url value="/ajaxApprove"/>",
+               {
+                   annId: "${announcement.id}",
+                   approval: true
+               },
+               function(){ 
+                   window.location = "<portlet:renderURL portletMode="view" windowState="normal"><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${ announcement.parent.id }"/></portlet:renderURL>"; 
+                   return false; 
+               }
+           );
+       });
+   }); 
+});
+</script>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -1,0 +1,36 @@
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+
+<div id="<portlet:namespace/>">
+
+<table width="100%" cellspacing="0" cellpadding="0" id="historyTable" class="tablesorter">
+<thead><tr><th>Topic</th><th>Announcement</th><th>Start Date</th><th>End Date</th><td>Repost</td><td>Delete</td></tr></thead>
+<tbody>
+<c:forEach items="${announcements}" var="ann">
+	<tr>
+		<td><c:out value="${ann.parent.title}"/></td>
+		<td><a title="Click to Preview"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a><br /><c:out value="${ann.abstractText}"/></td>
+		<td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/></td>
+		<td><fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
+		<td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="show.viewedit"/>"><img alt="<spring:message code="show.viewedit"/>" src="<c:url value="/icons/pencil.png"/>" border="0" height="16" width="16"/></a></td>
+		<td><a href="#" onclick="<portlet:namespace/>_delete('<portlet:actionURL><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="show.delete"/>"><img border="0" alt="<spring:message code="show.delete"/>" src="<c:url value="/icons/bin_empty.png"/>" height="16" width="16"/></a></td>
+	</tr>
+</c:forEach>
+</tbody>
+</table>
+
+<p style="text-align:right">
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${ topic.id }"/></portlet:renderURL>"><img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> Back to topic</a>
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"></portlet:renderURL>"><img src="<c:url value="/icons/house.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="general.adminhome"/></a>
+</p>
+
+<script type="text/javascript" src="https://webresources.uchicago.edu/js/jquery-1.3.2.min.js"></script>
+<script type="text/javascript" src="https://webresources.uchicago.edu/js/jquery.tablesorter.min.js"></script>
+<script type="text/javascript">
+var <portlet:namespace/>  = jQuery.noConflict(true);
+<portlet:namespace/>(document).ready(function(){	     
+		<portlet:namespace/>("#historyTable").tablesorter( {sortList: [[1,0], [2,0]]} ); 
+	} 
+);
+</script>
+
+</div> 

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -106,7 +106,7 @@ function <portlet:namespace/>approval(id, newValue) {
 						</c:otherwise>
 					</c:choose>
 
-					<td><c:out value="${ann.title}"/></td>
+					<td><a  title="Click to Preview"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a></td>
 					<td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/> - <fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
 
 					<td>
@@ -135,6 +135,9 @@ function <portlet:namespace/>approval(id, newValue) {
 <br/>
 <a style="text-decoration:none;" href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>">
 <img src="<c:url value="/icons/add.png"/>" height="16" width="16" style="vertical-align:middle" border="0"/> <spring:message code="show.addAnn"/></a>
+<br/>
+<a style="text-decoration:none;" href="<portlet:renderURL><portlet:param name="action" value="showHistory"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>">
+<spring:message code="show.history"/></a>
 <br/>
 <br/>
 


### PR DESCRIPTION
Hello uPortal devs: 

These are a few proposed enhancements for the AnnouncementsPortlet in regards to previewing announcements before they are published and allowing a user to view a set of previous announcements after they have expired from the main view.  We have been using these in our production environment for a while without issue.  Let me know if you think these can be worked into the portlet and be part of its next release.  Hopefully these changes will provide some benefit to other institutions using this portlet.  

Thanks.
Bill.
