### PR TITLE
ANNPLT-52

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/controller/AdminTopicController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/AdminTopicController.java
@@ -27,12 +27,14 @@ import java.util.Set;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletException;
+import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.announcements.UnauthorizedException;
 import org.jasig.portlet.announcements.model.Announcement;
+import org.jasig.portlet.announcements.model.AnnouncementSortStrategy;
 import org.jasig.portlet.announcements.model.Topic;
 import org.jasig.portlet.announcements.model.validators.TopicValidator;
 import org.jasig.portlet.announcements.service.IAnnouncementService;
@@ -55,6 +57,9 @@ import org.springframework.web.bind.support.SessionStatus;
 @RequestMapping("VIEW")
 public class AdminTopicController {
 
+    public static final String PREFERENCE_SORT_STRATEGY = "AdminTopicController.AnnouncementSortStrategy";
+    public static final String DEFAULT_SORT_STRATEGY = "START_DISPLAY_DATE_ASCENDING";
+
 	private static final Log log = LogFactory.getLog(AdminTopicController.class);
 
 	@Autowired
@@ -65,6 +70,7 @@ public class AdminTopicController {
 
 	@Autowired
 	private UserPermissionCheckerFactory userPermissionCheckerFactory = null;
+
 	/**
 	 * Add topic view controller, creates or fetches the topic for adding or editing
 	 * @param topicIdStr
@@ -174,6 +180,7 @@ public class AdminTopicController {
 	public String showTopic(@RequestParam("topicId") String topicId,
 			RenderRequest request, Model model) throws NumberFormatException, PortletException {
 
+	    PortletPreferences prefs = request.getPreferences();
 		Topic topic = announcementService.getTopic(Long.parseLong(topicId));
 
 		UserPermissionChecker upChecker = userPermissionCheckerFactory.createUserPermissionChecker(request, topic);
@@ -188,7 +195,7 @@ public class AdminTopicController {
 			annList = null;
 
 		if (annList != null) {
-			Collections.sort(annList);
+		    Collections.sort(annList,AnnouncementSortStrategy.getStrategy(prefs.getValue(PREFERENCE_SORT_STRATEGY,DEFAULT_SORT_STRATEGY)));
 		}
 
 		model.addAttribute("user", upChecker);

--- a/src/main/java/org/jasig/portlet/announcements/controller/AnnouncementsViewController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/AnnouncementsViewController.java
@@ -20,6 +20,7 @@ package org.jasig.portlet.announcements.controller;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.portlet.ActionRequest;
@@ -37,6 +38,7 @@ import net.sf.ehcache.Element;
 import org.apache.log4j.Logger;
 import org.jasig.portlet.announcements.UnauthorizedException;
 import org.jasig.portlet.announcements.model.Announcement;
+import org.jasig.portlet.announcements.model.AnnouncementSortStrategy;
 import org.jasig.portlet.announcements.model.Topic;
 import org.jasig.portlet.announcements.model.TopicSubscription;
 import org.jasig.portlet.announcements.service.IAnnouncementService;
@@ -59,7 +61,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class AnnouncementsViewController implements InitializingBean {
 
     private static final String GUEST_USERNAME = "guest";
-    private static final String PREFERENCE_DISPLAY_STARTDATE = "AnnouncementsViewController.displayPublishDate";
     private static final Logger logger = Logger.getLogger(AnnouncementsViewController.class);
     private Cache guestAnnouncementCache = null;
     private Boolean showDate = Boolean.TRUE;
@@ -76,8 +77,11 @@ public class AnnouncementsViewController implements InitializingBean {
     @Autowired(required=true)
     private IViewNameSelector viewNameSelector = null;
 
+    public static final String PREFERENCE_DISPLAY_STARTDATE = "AnnouncementsViewController.displayPublishDate";
     public static final String PREFERENCE_DISABLE_EDIT = "AnnouncementsViewController.PREFERENCE_DISABLE_EDIT";
     public static final String PREFERENCE_PAGE_SIZE = "AnnouncementsViewController.PAGE_SIZE";
+    public static final String PREFERENCE_SORT_STRATEGY = "AnnouncementsViewController.AnnouncementSortStrategy";
+    public static final String DEFAULT_SORT_STRATEGY = "START_DISPLAY_DATE_ASCENDING";
 
     /**
      * Main method of this display controller. Calculates which topics should be shown to
@@ -85,7 +89,8 @@ public class AnnouncementsViewController implements InitializingBean {
      * @param model
      * @param request
      * @param from
-     * @param to
+     * @param toimport java.util.Date;
+
      * @return
      * @throws PortletException
      */
@@ -138,8 +143,9 @@ public class AnnouncementsViewController implements InitializingBean {
             }
 
             // sort the list (since they are not sorted from the database)
-            Collections.sort(announcements);
-            Collections.sort(emergencyAnnouncements);
+            Comparator<Announcement> sortStrategy = AnnouncementSortStrategy.getStrategy(prefs.getValue(PREFERENCE_SORT_STRATEGY,DEFAULT_SORT_STRATEGY));
+            Collections.sort(announcements,sortStrategy);
+            Collections.sort(emergencyAnnouncements,sortStrategy);
 
             if (isGuest) {
                 if (logger.isDebugEnabled())

--- a/src/main/java/org/jasig/portlet/announcements/model/Announcement.java
+++ b/src/main/java/org/jasig/portlet/announcements/model/Announcement.java
@@ -6,9 +6,9 @@
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,7 @@ import java.util.Date;
 
 /**
  * @author Erik A. Olsson (eolsson@uci.edu)
- * 
+ *
  * $LastChangedBy$
  * $LastChangedDate$
  */
@@ -32,9 +32,9 @@ public class Announcement implements Comparable<Announcement> {
      * Useful for announcements with open-ended display periods.
      */
     public static final long MILLISECONDS_IN_A_YEAR = 1000L   // Milliseconds in a second
-                                                * 60L   // Seconds in a minute 
-                                                * 60L   // Minutes in an hour 
-                                                * 24L   // Hours in a day 
+                                                * 60L   // Seconds in a minute
+                                                * 60L   // Minutes in an hour
+                                                * 24L   // Hours in a day
                                                 * 365L; // Days in a year (basically)
 
     private String title;
@@ -48,14 +48,14 @@ public class Announcement implements Comparable<Announcement> {
 	private Boolean published = false;
 	private Topic parent;
 	private Long id;
-	
+
 	/**
 	 * @return the published
 	 */
 	public Boolean isPublished() {
 		return published;
 	}
-	
+
 	/**
 	 * @return the published
 	 */
@@ -69,11 +69,11 @@ public class Announcement implements Comparable<Announcement> {
 	public void setPublished(Boolean published) {
 		this.published = published;
 	}
-	
+
 	public boolean hasId() {
 		return (this.id != null);
 	}
-	
+
 	/**
 	 * @return the id
 	 */
@@ -125,8 +125,16 @@ public class Announcement implements Comparable<Announcement> {
 	 * @return the endDisplay
 	 */
 	public Date getEndDisplay() {
-		return endDisplay;
+	    return endDisplay;
 	}
+
+	public Date getNullSafeEndDisplay() {
+	    // Unspecified end date means the announcement does not expire;  we
+	    // will substitute a date in the future each time this item is
+        // evaluated.
+	    return endDisplay != null ? endDisplay : new Date(System.currentTimeMillis() + Announcement.MILLISECONDS_IN_A_YEAR);
+	}
+
 	/**
 	 * @return the message
 	 */
@@ -200,7 +208,7 @@ public class Announcement implements Comparable<Announcement> {
 	public void setLink(String link) {
 		this.link = link;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
@@ -213,23 +221,7 @@ public class Announcement implements Comparable<Announcement> {
 	// manipulate the sorting so that start date, then title, then id,
 	// are used to determine order of display appearance
 	public int compareTo(Announcement otherAnn) {
-		
-		switch (startDisplay.compareTo(otherAnn.getStartDisplay())) {
-			case -1 : return 1;
-			case 1 : return -1;
-			case 0 :
-				// Since the start dates are the same, we will differentiate against title 
-				switch (title.compareTo(otherAnn.getTitle())) {
-					case -1 :	return -1;
-					case 1 : return 1;
-					case 0 :
-						// Titles are the same, so we will compare id's, which are unique
-						return id.compareTo(otherAnn.getId());
-				 }
-		}
-		
-		// This return is never reached, though the compiler doesn't realise it,
-		return 0;
+	    return AnnouncementSortStrategy.START_DISPLAY_DATE_DESCENDING.getComparator().compare(this, otherAnn);
 	}
-	
+
 }

--- a/src/main/java/org/jasig/portlet/announcements/model/AnnouncementSortStrategy.java
+++ b/src/main/java/org/jasig/portlet/announcements/model/AnnouncementSortStrategy.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.announcements.model;
+
+import java.util.Comparator;
+
+/**
+ * @author Chris Waymire (cwaymire@unicon.net)
+ *
+ */
+public enum AnnouncementSortStrategy {
+        CREATE_DATE_ASCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        return ann1.getCreated().compareTo(ann2.getCreated());
+                    }
+                };
+            }
+        },
+        CREATE_DATE_DESCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        return CREATE_DATE_ASCENDING.getComparator().compare(ann1, ann2) * -1;
+                    }
+                };
+            }
+        },
+        START_DISPLAY_DATE_ASCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        return ann1.getStartDisplay().compareTo(ann2.getStartDisplay());
+                    }
+                };
+            }
+        },
+        START_DISPLAY_DATE_DESCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        return START_DISPLAY_DATE_ASCENDING.getComparator().compare(ann1, ann2) * -1;
+                    }
+                };
+            }
+        },
+        END_DISPLAY_DATE_ASCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        if((ann1.getEndDisplay() == null) || (ann2.getEndDisplay() ==  null)) {
+                            if((ann1.getEndDisplay() == null) && (ann2.getEndDisplay() == null)) {
+                                if(ann1.getTitle().equalsIgnoreCase(ann2.getTitle())) {
+                                    return ann1.getId().compareTo(ann2.getId());
+                                } else {
+                                    return ann1.getTitle().compareTo(ann2.getTitle());
+                                }
+                            } else {
+                                return ann1.getEndDisplay() == null ? 1 : -1;
+                            }
+                        } else {
+                            return ann1.getEndDisplay().compareTo(ann2.getEndDisplay());
+                        }
+                    }
+                };
+            }
+        },
+        END_DISPLAY_DATE_DESCENDING() {
+            public Comparator<Announcement> getComparator() {
+                return new Comparator<Announcement>() {
+                    public int compare(Announcement ann1, Announcement ann2) {
+                        return END_DISPLAY_DATE_ASCENDING.getComparator().compare(ann1, ann2) * -1;
+                    }
+                };
+            }
+        },
+        DEFAULT() {
+            public Comparator<Announcement> getComparator() {
+                return START_DISPLAY_DATE_DESCENDING.getComparator();
+            }
+        }
+        ;
+
+        private AnnouncementSortStrategy() { }
+        abstract public Comparator<Announcement> getComparator();
+
+        public static Comparator<Announcement> getStrategy(String strategyName) {
+            AnnouncementSortStrategy strategy = AnnouncementSortStrategy.valueOf(strategyName);
+            return strategy != null ? strategy.getComparator() : DEFAULT.getComparator();
+        }
+}

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -25,15 +25,15 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_1_0.xsd
     http://java.sun.com/xml/ns/portlet/portlet-app_1_0.xsd"
     version="1.0">
-    
+
     <!-- IMPORTANT: For this portlet to work, you must mirror all <security-role-ref> elements in both portlet sections!! -->
-    
+
     <portlet>
         <portlet-name>AnnouncementsDisplay</portlet-name>
         <display-name xml:lang="en">Announcements</display-name>
         <display-name xml:lang="sv">Tillk&#228;nnagivanden</display-name>
         <display-name xml:lang="fr">Annonces</display-name>
-        
+
         <portlet-class>org.springframework.web.portlet.DispatcherPortlet</portlet-class>
         <init-param>
             <name>contextConfigLocation</name>
@@ -44,18 +44,32 @@
             <portlet-mode>view</portlet-mode>
             <portlet-mode>edit</portlet-mode>
         </supports>
-        
+
         <supported-locale>en</supported-locale>
         <supported-locale>sv</supported-locale>
         <supported-locale>fr</supported-locale>
-        
+
         <resource-bundle>i18n/ann-portlet</resource-bundle>
-        
+
         <portlet-preferences>
             <preference>
                 <name>AnnouncementsViewController.displayPublishDate</name>
                 <value>false</value>
                 <read-only>true</read-only>
+            </preference>
+            <preference>
+                <!--
+                    Available Strategies:
+                    CREATE_DATE_ASCENDING
+                    CREATE_DATE_DESCENDING
+                    START_DISPLAY_DATE_ASCENDING
+                    START_DISPLAY_DATE_DESCENDING
+                    END_DISPLAY_DATE_ASCENDING
+                    END_DISPLAY_DATE_DESCENDING
+                 -->
+                <name>AnnouncementsViewController.AnnouncementSortStrategy</name>
+                <value>START_DISPLAY_DATE_DESCENDING</value>
+                <read-only>false</read-only>
             </preference>
         </portlet-preferences>
 
@@ -64,45 +78,45 @@
             <role-name>Portal_Administrators</role-name>
             <role-link>local.2</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Everyone</role-name>
             <role-link>local.0</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>All_Logged_In_Users</role-name>
             <role-link>pags.1</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Faculty</role-name>
             <role-link>local.23</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Staff</role-name>
             <role-link>local.33</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Students</role-name>
             <role-link>local.34</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Grad_Students</role-name>
             <role-link>local.26</role-link>
         </security-role-ref>
-        
+
     </portlet>
-    
+
     <portlet>
         <portlet-name>AnnouncementsAdmin</portlet-name>
         <display-name xml:lang="en">Announcement Administration</display-name>
         <display-name xml:lang="sv">Administrera Tillk&#228;nnagivanden</display-name>
-        <display-name xml:lang="fr">Administration Annonces</display-name> 
-        
+        <display-name xml:lang="fr">Administration Annonces</display-name>
+
         <portlet-class>org.springframework.web.portlet.DispatcherPortlet</portlet-class>
         <init-param>
             <name>contextConfigLocation</name>
@@ -112,13 +126,13 @@
             <mime-type>text/html</mime-type>
             <portlet-mode>view</portlet-mode>
         </supports>
-        
+
         <supported-locale>en</supported-locale>
         <supported-locale>sv</supported-locale>
         <supported-locale>fr</supported-locale>
-        
+
         <resource-bundle>i18n/ann-admin-portlet</resource-bundle>
-        
+
         <portlet-preferences>
             <preference>
                 <name>AdminAnnouncementController.allowOpenEndDate</name>
@@ -132,43 +146,43 @@
             <role-name>Portal_Administrators</role-name>
             <role-link>local.2</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Everyone</role-name>
             <role-link>local.0</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>All_Logged_In_Users</role-name>
             <role-link>pags.1</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Faculty</role-name>
             <role-link>local.23</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Staff</role-name>
             <role-link>local.33</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Students</role-name>
             <role-link>local.34</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Grad_Students</role-name>
             <role-link>local.26</role-link>
         </security-role-ref>
-        
+
     </portlet>
-    
+
     <portlet>
         <portlet-name>WhitelistAnnouncementsDisplay</portlet-name>
         <display-name xml:lang="en">Whitelist Announcements</display-name>
-        
+
         <portlet-class>org.springframework.web.portlet.DispatcherPortlet</portlet-class>
         <init-param>
             <name>contextConfigLocation</name>
@@ -179,13 +193,13 @@
             <portlet-mode>view</portlet-mode>
             <portlet-mode>edit</portlet-mode>
         </supports>
-        
+
         <supported-locale>en</supported-locale>
         <supported-locale>sv</supported-locale>
         <supported-locale>fr</supported-locale>
-        
+
         <resource-bundle>i18n/ann-portlet</resource-bundle>
-        
+
         <portlet-preferences>
             <preference>
                 <name>PortletPreferencesTopicSubscriptionService.topicWhitelist</name>
@@ -202,44 +216,58 @@
                 <value>false</value>
                 <read-only>true</read-only>
             </preference>
+            <preference>
+                <!--
+                    Available Strategies:
+                    CREATE_DATE_ASCENDING
+                    CREATE_DATE_DESCENDING
+                    START_DISPLAY_DATE_ASCENDING
+                    START_DISPLAY_DATE_DESCENDING
+                    END_DISPLAY_DATE_ASCENDING
+                    END_DISPLAY_DATE_DESCENDING
+                 -->
+                <name>AdminTopicController.AnnouncementSortStrategy</name>
+                <value>START_DISPLAY_DATE_DESCENDING</value>
+                <read-only>false</read-only>
+            </preference>
         </portlet-preferences>
-        
+
         <!-- Do not change the role-name of this role, doing so may lock you out of your topics -->
         <security-role-ref>
             <role-name>Portal_Administrators</role-name>
             <role-link>local.2</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Everyone</role-name>
             <role-link>local.0</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>All_Logged_In_Users</role-name>
             <role-link>pags.1</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Faculty</role-name>
             <role-link>local.23</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Staff</role-name>
             <role-link>local.33</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Students</role-name>
             <role-link>local.34</role-link>
         </security-role-ref>
-        
+
         <security-role-ref>
             <role-name>Grad_Students</role-name>
             <role-link>local.26</role-link>
         </security-role-ref>
-        
+
     </portlet>
 
 </portlet-app>


### PR DESCRIPTION
Implement a sorting strategy system whereby portlet admins can choose how they want the Admin and Display portlets to be (independently) sorted. Sorting is performed by the introduction of various predefined comparators wrapped up into an enum.

Add new portlet preferences to both the Display and Admin portlets defining the default/standard sorting strategy.
