### PR TITLE
NOJIRA: Add a "Help" link to the bottom of the base admin page

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -25,6 +25,7 @@ general.moderators=Editors
 general.authors=Contributors
 general.audience=Audience Members
 general.cancelandreturn=Cancel and Return
+general.help=Help Information
 
 ## addAnnouncement.jsp ##
 addAnnouncement.header=Announcement for

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -205,3 +205,9 @@
 	<img src="<c:url value="/icons/add.png"/>" border="0" height="16" width="16" style="vertical-align:middle;"/> <spring:message code="baseAdmin.addnew"/>
 	</a>
 </c:if>
+
+<div style="float:right;">
+    <a href="<portlet:renderURL portletMode='HELP' windowState='MAXIMIZED'/>" style="float:right;">
+        <img src="<c:url value='/icons/exclamation.png'/>" border="0" style="vertical-align: middle;"/><spring:message code="general.help"/>
+    </a>
+</div>


### PR DESCRIPTION
Add a "Help" link to the bottom of the base admin page in the Announcements Admin portlet that redirects to the HELP mode with a maximized window state.
