### PR TITLE
ANNPLT-81:

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/controller/AdminAnnouncementController.java
+++ b/src/main/java/org/jasig/portlet/announcements/controller/AdminAnnouncementController.java
@@ -59,7 +59,7 @@ public class AdminAnnouncementController implements InitializingBean {
     public static final String PREFERENCE_ABSTRACT_MAX_LENGTH = "AdminAnnouncementController.abstractTextMaxLength";
     public static final String PREFERENCE_TINY_MCE_INITIALIZATION_OPTIONS = "AdminAnnouncementController.tinyMceInitializationOptions";
     public static final String DEFAULT_ABSTRACT_MAX_LENGTH = "255";
-    public static final String DEFAULT_TINY_MCE_INITIALIZATION_OPTIONS = "mode:\"textareas\", " +
+    public static final String[] DEFAULT_TINY_MCE_INITIALIZATION_OPTIONS = {"mode:\"textareas\", " +
                                                                          " editor_selector:\"mceEditor\", " +
                                                                          " theme:\"advanced\", " +
                                                                          " plugins:\"paste,preview\", " +
@@ -69,7 +69,7 @@ public class AdminAnnouncementController implements InitializingBean {
                                                                          " theme_advanced_toolbar_location:\"top\", " +
                                                                          " theme_advanced_toolbar_align:\"left\", " +
                                                                          " extended_valid_elements:\"a[name|href|target|title|onclick],span[class|align|style]\", " +
-                                                                         " theme_advanced_path:false";
+                                                                         " theme_advanced_path:false"};
 
 
     @Autowired
@@ -140,11 +140,27 @@ public class AdminAnnouncementController implements InitializingBean {
 
             model.addAttribute("announcement", ann);
         }
-
+        String[] tinyMceInitializationParameters = prefs.getValues(PREFERENCE_TINY_MCE_INITIALIZATION_OPTIONS, DEFAULT_TINY_MCE_INITIALIZATION_OPTIONS);
         model.addAttribute("datePickerFormat", datePickerFormat);
         model.addAttribute("abstractMaxLength",prefs.getValue(PREFERENCE_ABSTRACT_MAX_LENGTH,DEFAULT_ABSTRACT_MAX_LENGTH));
-        model.addAttribute("tinyMceInitializationOptions", prefs.getValue(PREFERENCE_TINY_MCE_INITIALIZATION_OPTIONS, DEFAULT_TINY_MCE_INITIALIZATION_OPTIONS));
+        model.addAttribute("tinyMceInitializationOptions", decodeCommas(concatenateTinyMceInitialParameters(tinyMceInitializationParameters)));
         return "addAnnouncement";
+    }
+
+    private String decodeCommas(String original) {
+        return original.replaceAll("%2C", ",");
+    }
+
+    private String concatenateTinyMceInitialParameters(String[] tinyMceInitializationParameters) {
+        StringBuffer finalTinyMceInitializationParameters = new StringBuffer();
+        for( int i = 0; i <= tinyMceInitializationParameters.length - 1; i++) {
+            if (i == 0) {
+                finalTinyMceInitializationParameters.append(tinyMceInitializationParameters[i]);
+            } else {
+                finalTinyMceInitializationParameters.append(", ").append(tinyMceInitializationParameters[i]);
+            }
+        }
+        return finalTinyMceInitializationParameters.toString();
     }
 
     /**

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -87,6 +87,20 @@
                 <read-only>false</read-only>
             </preference>
             <preference>
+                <!--
+                    Available Strategies:
+                    CREATE_DATE_ASCENDING
+                    CREATE_DATE_DESCENDING
+                    START_DISPLAY_DATE_ASCENDING
+                    START_DISPLAY_DATE_DESCENDING
+                    END_DISPLAY_DATE_ASCENDING
+                    END_DISPLAY_DATE_DESCENDING
+                 -->
+                <name>AnnouncementsViewController.AnnouncementHistorySortStrategy</name>
+                <value>END_DISPLAY_DATE_DESCENDING</value>
+                <read-only>false</read-only>
+            </preference>
+            <preference>
                 <name>AnnouncementsViewController.useScrollingDisplay</name>
                 <value>false</value>
                 <read-only>false</read-only>
@@ -212,7 +226,7 @@
             </preference>
             <preference>
                 <name>AdminAnnouncementController.tinyMceInitializationOptions</name>
-                <value>mode:"textareas", editor_selector:"mceEditor", theme:"advanced", plugins:"paste,preview", theme_advanced_buttons1:"bold,italic,underline,strikethrough,separator,outdent,indent,blockquote,separator,fontselect,fontsizeselect", theme_advanced_buttons2:"cut,copy,paste,pastetext,pasteword,separator,bullist,numlist,separator,charmap,emotions", theme_advanced_buttons3:"undo,redo,separator,link,unlink,image,anchor,cleanup,help,separator,code,preview", theme_advanced_toolbar_location:"top", theme_advanced_toolbar_align:"left", extended_valid_elements:"a[name|href|target|title|onclick],span[class|align|style]", theme_advanced_path:false</value>
+                <value>mode:"textareas"%2C editor_selector:"mceEditor"%2C theme:"advanced"%2C plugins:"paste%2Cpreview"%2C theme_advanced_buttons1:"bold%2Citalic%2Cunderline%2Cstrikethrough%2Cseparator%2Coutdent%2Cindent%2Cblockquote%2Cseparator%2Cfontselect%2Cfontsizeselect"%2C theme_advanced_buttons2:"cut%2Ccopy%2Cpaste%2Cpastetext%2Cpasteword%2Cseparator%2Cbullist%2Cnumlist%2Cseparator%2Ccharmap%2Cemotions"%2C theme_advanced_buttons3:"undo%2Credo%2Cseparator%2Clink%2Cunlink%2Cimage%2Canchor%2Ccleanup%2Chelp%2Cseparator%2Ccode%2Cpreview"%2C theme_advanced_toolbar_location:"top"%2C theme_advanced_toolbar_align:"left"%2C extended_valid_elements:"a[name|href|target|title|onclick]%2Cspan[class|align|style]"%2C theme_advanced_path:false</value>
                 <read-only>false</read-only>
             </preference>
         </portlet-preferences>


### PR DESCRIPTION
- Adding decoding of comma for tiny mce init param as a work around to portlet preferences UI automatically splitting on comma
- Updated default to encoded commas for tiny mce init param
- Updated to allow tiny mce init param to be multivalue
