### PR TITLE
ANNPLT-120: Link labels to inputs

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
@@ -131,7 +131,7 @@
     <div class="container-fluid bootstrap-styles announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
-                <h4 role="heading"><spring:message code="addAnnouncement.header"/> <c:out value="${announcement.parent.title}"/></h4>
+                <h4><spring:message code="addAnnouncement.header"/> <c:out value="${announcement.parent.title}"/></h4>
             </div>
             <div class="col-md-6 no-col-padding">
                 <div class="nav-links">
@@ -144,14 +144,18 @@
             <div class="col-md-12">
                 <form:form commandName="announcement" method="post" action="${actionUrl}" class="form-horizontal" role="form">
                     <div class="form-group">
-                        <label for="title" class="col-sm-3 control-label"><spring:message code="addAnnouncement.title"/></label>
+                        <label for="title" class="col-sm-3 control-label">
+                            <spring:message code="addAnnouncement.title"/>
+                        </label>
                         <div class="col-sm-9">
                             <form:input cssClass="form-control" path="title"/>
                             <form:errors cssClass="announcements-error label label-danger" path="title"/>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="${n}abstractText" class="col-sm-3 control-label"><spring:message code="addAnnouncement.abstract"/></label>
+                        <label for="${n}abstractText" class="col-sm-3 control-label">
+                            <spring:message code="addAnnouncement.abstract"/>
+                        </label>
                         <div class="col-sm-9">
                             <form:textarea cssClass="form-control" path="abstractText" id="${n}abstractText"/>
                             <form:errors cssClass="announcements-error label label-danger" path="abstractText"/>
@@ -159,7 +163,9 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-sm-3 control-label"><spring:message code="addAnnouncement.message"/></label>
+                        <label class="col-sm-3 control-label">
+                            <spring:message code="addAnnouncement.message"/>
+                        </label>
                         <div class="col-sm-9">
                             <%-- Removed textarea and replaced with a div that TinyMCE 4.x uses with inline editing.
                                  Must set id on div because TinyMCE will use that as the added hidden form field name.
@@ -169,14 +175,18 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-sm-3 control-label"><spring:message code="addAnnouncement.link"/></label>
+                        <label class="col-sm-3 control-label" for="link">
+                            <spring:message code="addAnnouncement.link"/>
+                        </label>
                         <div class="col-sm-9">
                             <form:errors cssClass="announcements-error label label-danger" path="link"/>
                             <form:input cssClass="form-control" path="link"/>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-sm-3 control-label"><spring:message code="addAnnouncement.start"/></label>
+                        <label class="col-sm-3 control-label" for="${n}datepickerStart">
+                            <spring:message code="addAnnouncement.start"/>
+                        </label>
                         <div class="col-sm-9">
                             <div class="input-group">
                                 <form:input path="startDisplay" cssClass="form-control" id="${n}datepickerStart"/>
@@ -186,7 +196,9 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-sm-3 control-label"><spring:message code="addAnnouncement.end"/></label>
+                        <label class="col-sm-3 control-label" for="${n}datepickerEnd">
+                            <spring:message code="addAnnouncement.end"/>
+                        </label>
                         <div class="col-sm-9">
                             <div class="input-group">
                                 <form:input path="endDisplay" cssClass="form-control" id="${n}datepickerEnd"/>

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -22,7 +22,7 @@
 
 <c:set var="n"><portlet:namespace/></c:set>
 <portlet:actionURL var="actionUrl" escapeXml="false">
-	<portlet:param name="action" value="addTopic"/>
+		<portlet:param name="action" value="addTopic"/>
 </portlet:actionURL>
 
 <link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
@@ -71,11 +71,16 @@
 <div class="container-fluid bootstrap-styles announcements-container">
     <div class="row announcements-portlet-toolbar">
         <div class="col-md-8 no-col-padding">
-            <h4 role="heading"><spring:message code="addTopic.heading"/></h4>
+            <h4>
+								<spring:message code="addTopic.heading"/>
+						</h4>
         </div>
         <div class="col-md-4 no-col-padding">
             <div class="nav-links">
-                <a href="<portlet:renderURL />"><i class="fa fa-home"></i> <spring:message code="general.adminhome"/></a>
+                <a href="<portlet:renderURL />">
+										<i class="fa fa-home"></i>
+										<spring:message code="general.adminhome"/>
+								</a>
             </div>
         </div>
     </div>
@@ -83,20 +88,26 @@
         <div class="col-md-12">
             <form:form commandName="topic" method="post" action="${actionUrl}" class="form-horizontal" role="form">
                 <div class="form-group">
-                    <label for="title" class="col-sm-3 control-label"><spring:message code="addTopic.title"/></label>
+                    <label for="title" class="col-sm-3 control-label">
+												<spring:message code="addTopic.title"/>
+										</label>
                     <div class="col-sm-9">
                         <form:input cssClass="form-control" path="title"/>
                         <form:errors cssClass="announcements-error label label-danger" path="title"/>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="description" class="col-sm-3 control-label"><spring:message code="addTopic.description"/></label>
+                    <label for="description" class="col-sm-3 control-label">
+												<spring:message code="addTopic.description"/>
+										</label>
                     <div class="col-sm-9">
                         <form:textarea cssClass="form-control" path="description"/>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="allowRss1" class="col-sm-3 control-label"><spring:message code="addTopic.publicrss"/></label>
+                    <label for="allowRss1" class="col-sm-3 control-label">
+												<spring:message code="addTopic.publicrss"/>
+										</label>
                     <div class="col-sm-9">
                         <div class="checkbox">
                             <form:checkbox path="allowRss" cssClass="portlet-form-input-field"/>
@@ -104,22 +115,27 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="subscriptionMethod" class="col-sm-3 control-label"><spring:message code="addTopic.submethod"/></label>
+                    <label for="subscriptionMethod" class="col-sm-3 control-label">
+												<spring:message code="addTopic.submethod"/>
+										</label>
                     <div class="col-sm-9">
                         <div class="radio">
-                            <label for="subscriptionMethod1" title="<spring:message code="addTopic.pushedforced.title"/>"><spring:message code="addTopic.pushedforced"/>
+                            <label for="subscriptionMethod1" title="<spring:message code="addTopic.pushedforced.title"/>">
                                 <form:radiobutton path="subscriptionMethod" value="1"/>
+																<spring:message code="addTopic.pushedforced"/>
                             </label>
                         </div>
                         <div class="radio">
-                            <label for="subscriptionMethod2" title="<spring:message code="addTopic.pushedoptional.title"/>"><spring:message code="addTopic.pushedoptional"/>
+                            <label for="subscriptionMethod2" title="<spring:message code="addTopic.pushedoptional.title"/>">
                                 <form:radiobutton path="subscriptionMethod" value="2"/>
+																<spring:message code="addTopic.pushedoptional"/>
                             </label>
                         </div>
                         <div class="radio">
-                                <label for="subscriptionMethod3" title="<spring:message code="addTopic.optional.title"/>"><spring:message code="addTopic.optional"/>
+                            <label for="subscriptionMethod3" title="<spring:message code="addTopic.optional.title"/>">
                                 <form:radiobutton path="subscriptionMethod" value="3"/>
-                                </label>
+																<spring:message code="addTopic.optional"/>
+                            </label>
                         </div>
                         <form:errors cssClass="announcements-error label label-danger" path="subscriptionMethod"/>
                     </div>
@@ -128,13 +144,15 @@
                 <form:hidden path="creator"/>
                 <div class="form-group">
                     <div class="col-sm-9 col-sm-offset-3">
-                        <button type="submit" class="btn btn-primary"><spring:message code="addTopic.saveButton"/></button>
-                        <a class="btn btn-link" href="<portlet:renderURL />"><spring:message code="addTopic.cancel"/></a>
+                        <button type="submit" class="btn btn-primary">
+														<spring:message code="addTopic.saveButton"/>
+												</button>
+                        <a class="btn btn-link" href="<portlet:renderURL />">
+														<spring:message code="addTopic.cancel"/>
+												</a>
                     </div>
                 </div>
             </form:form>
         </div>
     </div>
 </div>
-
-


### PR DESCRIPTION
https://issues.jasig.org/browse/ANNPLT-120

#### Issue

This text input element does not have a name available to an accessibility API. Valid names are: label element, title attribute.

*Code Snippet*

``` html
<input id="link" name="link" class="form-control" type="text" value="">
<input id="Pluto_44_u13l1n11_14_datepickerStart" name="startDisplay" class="form-control hasDatepicker" type="text" value="">
<input id="Pluto_44_u13l1n11_14_datepickerEnd" name="endDisplay" class="form-control hasDatepicker" type="text" value="">
```

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.
When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.

*Code Snippet*

``` html
<input id="link" name="link" class="form-control" type="text" value="">
<input id="Pluto_44_u13l1n11_14_datepickerStart" name="startDisplay" class="form-control hasDatepicker" type="text" value="">
<input id="Pluto_44_u13l1n11_14_datepickerEnd" name="endDisplay" class="form-control hasDatepicker" type="text" value="">
```

Change order of text and radio buttons so page renders as expected

#### Resolution

Added `for="id"` to `<label>` tags.