### PR TITLE
ANNPLT-128: Correct ADA violations in student and admin views

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -82,7 +82,10 @@ baseAdmin.topics=Topics
 baseAdmin.manage=Manage
 baseAdmin.edit=Edit
 baseAdmin.delete=Delete
+baseAdmin.help=Help
 baseAdmin.addnew=Add a new Topic
+baseAdmin.no.subMethod=Special
+baseAdmin.no.actions=None
 baseAdmin.myapprovals=My Approvals
 baseAdmin.approve=Approve
 baseAdmin.waitingapproval=Announcements waiting for your approval
@@ -104,6 +107,7 @@ display.link.history=Archives
 display.header.start=Start Date
 display.header.end=End Date
 display.back=Back to Home
+display.no.history=There are no announcements in the archive.
 displayFullHistory.back=Back to announcement history
 
 ## displayFullAnnouncement.jsp ##

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -73,6 +73,7 @@ addTopic.saveButton=Save Topic
 addTopic.cancel=Cancel
 
 ## baseAdmin.jsp ##
+baseAdmin.table=Topics
 baseAdmin.header.topics=Topics
 baseAdmin.header.status=Active, Scheduled, Pending
 baseAdmin.header.subscriptionmethod=Subscription Method
@@ -104,6 +105,7 @@ display.no.announcements=There are no announcements at this time.
 display.link.history=Archives
 
 ## displayHistory ##
+display.table=History
 display.header.start=Start Date
 display.header.end=End Date
 display.back=Back to Home
@@ -138,6 +140,7 @@ errorPermission.message=You don't have the permissions required to perform that 
 show.deleteAnn=Are you sure you want to delete this announcement?
 show.annfor=Announcements for
 show.none=No announcements showing, scheduled or pending.
+show.table=Announcements
 show.head.status=Status
 show.head.title=Title
 show.head.displaying=Displaying
@@ -164,6 +167,7 @@ preview.fullview=Full Announcement View
 
 ## showHistory.jsp ##
 showHistory.history=History
+showHistory.table=Topic History 
 showHistory.header.topic=Topic
 showHistory.header.ann=Announcement
 showHistory.header.start=Start Date

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -141,6 +141,7 @@ show.none=No announcements showing, scheduled or pending.
 show.head.status=Status
 show.head.title=Title
 show.head.displaying=Displaying
+show.head.actions=Actions
 show.scheduled=Scheduled
 show.showing=Showing
 show.pending=Pending

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -66,6 +66,7 @@ addTopic.saveButton=Enregistrer
 addTopic.cancel=Annuler
 
 ## baseAdmin.jsp ##
+baseAdmin.table=Th&egrave;mes
 baseAdmin.header.topics=Th&egrave;mes
 baseAdmin.header.status=Affich&eacute;, Planifi&eacute;, En attente
 baseAdmin.header.subscriptionmethod=M&eacute;thode de souscription
@@ -97,10 +98,11 @@ display.no.announcements=Il n&apos;y a pas d&apos;annonces &agrave; ce moment.
 display.link.history=Annonces archiv&eacute;es
 
 ## displayHistory ##
+display.table=Histoire
 display.header.start=Date de d&eacute;but
 display.header.end=Date de fin
 display.back=Retour
-display.no.history=C&apos;est vide
+display.no.history=Il n&apos;y a pas d&apos;annonce...
 displayFullHistory.back=Retour &agrave; l&apos;historique
 
 ## displayFullAnnouncement.jsp ##
@@ -131,6 +133,7 @@ errorPermission.message=Vous n&apos;&ecirc;tes pas autoris&eacute; &agrave; effe
 show.deleteAnn=Etes-vous s&ucirc;r de vouloir supprimer cette annonce ?
 show.annfor=Annonces du th&egrave;me
 show.none=Aucune annonce
+show.table=Annonces
 show.head.status=Statut
 show.head.title=Titre
 show.head.displaying=Affichage en cours
@@ -157,6 +160,7 @@ preview.fullview=Vue compl&egrave;te de l&apos;annonce
 
 ## showHistory.jsp ##
 showHistory.history=Historique
+showHistory.table=Histoire du Th&egrave;me
 showHistory.header.topic=Th&egrave;me
 showHistory.header.ann=Annonce
 showHistory.header.start=Date de d&eacute;but

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -37,6 +37,8 @@ addAnnouncement.start=Du :
 addAnnouncement.end=Au :
 addAnnouncement.save=Enregistrer
 addAnnouncement.charactersremaining=caract&egrave;res restants.
+addAnnouncement.attachments=Pi&egrave;ces jointes
+addAnnouncement.cancel=Annuler
 
 ## addMembers.jsp ##
 addMembers.assigning=Assigner
@@ -46,6 +48,7 @@ addMembers.users=Utilisateurs
 addMembers.deleteUser=Supprimer
 addMembers.addUser=Ajouter un identifiant:
 addMembers.addUserButton=Ajouter
+addMembers.cancel=Annuler
 
 ## addTopic.jsp ##
 addTopic.heading=Ajout d&apos;un th&egrave;me
@@ -60,6 +63,7 @@ addTopic.pushedoptional.title=Cette m&eacute;thode de souscription abonne tous l
 addTopic.optional=Non abonn&eacute;, optionnel
 addTopic.optional.title=Cette m&eacute;thode de souscription rend ce th&egrave;me disponible pour tout membre de l&apos;audience, mais l&apos;utilisateur doit s&apos;y abonner manuellement pour pouvoir le voir.
 addTopic.saveButton=Enregistrer
+addTopic.cancel=Annuler
 
 ## baseAdmin.jsp ##
 baseAdmin.header.topics=Th&egrave;mes
@@ -71,7 +75,10 @@ baseAdmin.topics=Th&egrave;mes
 baseAdmin.manage=Administrer
 baseAdmin.edit=Editer
 baseAdmin.delete=Supprimer
+baseAdmin.help=Aide
 baseAdmin.addnew=Ajouter un th&egrave;me
+baseAdmin.no.subMethod=Sp&eacutecial
+baseAdmin.no.actions=Nul
 baseAdmin.myapprovals=Mes approbations
 baseAdmin.approve=Approuver
 baseAdmin.waitingapproval=annonces en attente pour approbation
@@ -93,6 +100,7 @@ display.link.history=Annonces archiv&eacute;es
 display.header.start=Date de d&eacute;but
 display.header.end=Date de fin
 display.back=Retour
+display.no.history=C&apos;est vide
 displayFullHistory.back=Retour &agrave; l&apos;historique
 
 ## displayFullAnnouncement.jsp ##
@@ -101,6 +109,7 @@ displayFull.displayBegin=Publi&eacute;
 displayFull.displayEnd=Affich&eacute;e jusqu&apos;au
 displayFull.displayEnd.unspecified=Ind&eacute;termin&eacute;
 displayFull.back=Retour
+displayFull.attachments=Pi&egrave;ces jointes
 
 ## editDisplayPreferences.jsp ##
 edit.yoursubs=Mes abonnements

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -134,6 +134,7 @@ show.none=Aucune annonce
 show.head.status=Statut
 show.head.title=Titre
 show.head.displaying=Affichage en cours
+show.head.actions=Actions
 show.scheduled=Affichage planifi&eacute;
 show.showing=Affichage en cours
 show.pending=En attente

--- a/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
@@ -134,8 +134,8 @@
             </div>
             <div class="col-md-6 no-col-padding">
                 <div class="nav-links">
-                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${announcement.parent.id}"/></portlet:renderURL>"><i class="fa fa-arrow-left"></i> <spring:message code="general.backtotopic"/></a> |
-                    <a href="<portlet:renderURL />"><i class="fa fa-home"></i> <spring:message code="general.adminhome"/></a>
+                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${announcement.parent.id}"/></portlet:renderURL>"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="general.backtotopic"/></a> |
+                    <a href="<portlet:renderURL />"><i class="fa fa-home" aria-hidden="true"></i> <spring:message code="general.adminhome"/></a>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/addMembers.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addMembers.jsp
@@ -50,8 +50,8 @@
             </div>
             <div class="col-md-6 no-col-padding">
                 <div class="nav-links">
-                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><i class="fa fa-arrow-left"></i> <spring:message code="general.backtotopic"/></a> |
-                    <a href="<portlet:renderURL />"><i class="fa fa-home"></i> <spring:message code="general.adminhome"/></a>
+                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="general.backtotopic"/></a> |
+                    <a href="<portlet:renderURL />"><i class="fa fa-home" aria-hidden="true"></i> <spring:message code="general.adminhome"/></a>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -77,7 +77,7 @@
         <div class="col-md-4 no-col-padding">
             <div class="nav-links">
                 <a href="<portlet:renderURL />">
-										<i class="fa fa-home"></i>
+										<i class="fa fa-home" aria-hidden="true"></i>
 										<spring:message code="general.adminhome"/>
 								</a>
             </div>

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -113,32 +113,32 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group" id="radio_group">
-                    <label for="subscriptionMethod" class="col-sm-3 control-label">
-												<spring:message code="addTopic.submethod"/>
-										</label>
-                    <div class="col-sm-9" aria-labelledby="radio_group" aria-required="true" role="radiogroup">
+                <fieldset class="form-group">
+                    <legend class="col-sm-3 control-label" id="radio-label">
+                        <spring:message code="addTopic.submethod"/>
+                    </legend>
+                    <div class="col-sm-9" aria-required="true" role="radiogroup" aria-labelledby="radio-label">
                         <div class="radio">
+                            <form:radiobutton role="radio" path="subscriptionMethod" value="1"/>
                             <label for="subscriptionMethod1" title="<spring:message code="addTopic.pushedforced.title"/>">
-                                <form:radiobutton role="radio" path="subscriptionMethod" value="1"/>
-																<spring:message code="addTopic.pushedforced"/>
+                                <spring:message code="addTopic.pushedforced"/>
                             </label>
                         </div>
                         <div class="radio">
+                            <form:radiobutton role="radio" path="subscriptionMethod" value="2"/>
                             <label for="subscriptionMethod2" title="<spring:message code="addTopic.pushedoptional.title"/>">
-                                <form:radiobutton role="radio" path="subscriptionMethod" value="2"/>
-																<spring:message code="addTopic.pushedoptional"/>
+                                <spring:message code="addTopic.pushedoptional"/>
                             </label>
                         </div>
                         <div class="radio">
+                            <form:radiobutton role="radio" path="subscriptionMethod" value="3"/>
                             <label for="subscriptionMethod3" title="<spring:message code="addTopic.optional.title"/>">
-                                <form:radiobutton role="radio" path="subscriptionMethod" value="3"/>
-																<spring:message code="addTopic.optional"/>
+                                <spring:message code="addTopic.optional"/>
                             </label>
                         </div>
                         <form:errors cssClass="announcements-error label label-danger" path="subscriptionMethod"/>
                     </div>
-                </div>
+                </fieldset>
                 <form:hidden path="id"/>
                 <form:hidden path="creator"/>
                 <div class="form-group">

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -113,26 +113,26 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group" id="radio_group">
                     <label for="subscriptionMethod" class="col-sm-3 control-label">
 												<spring:message code="addTopic.submethod"/>
 										</label>
-                    <div class="col-sm-9">
+                    <div class="col-sm-9" aria-labelledby="radio_group" aria-required="true" role="radiogroup">
                         <div class="radio">
                             <label for="subscriptionMethod1" title="<spring:message code="addTopic.pushedforced.title"/>">
-                                <form:radiobutton path="subscriptionMethod" value="1"/>
+                                <form:radiobutton role="radio" path="subscriptionMethod" value="1"/>
 																<spring:message code="addTopic.pushedforced"/>
                             </label>
                         </div>
                         <div class="radio">
                             <label for="subscriptionMethod2" title="<spring:message code="addTopic.pushedoptional.title"/>">
-                                <form:radiobutton path="subscriptionMethod" value="2"/>
+                                <form:radiobutton role="radio" path="subscriptionMethod" value="2"/>
 																<spring:message code="addTopic.pushedoptional"/>
                             </label>
                         </div>
                         <div class="radio">
                             <label for="subscriptionMethod3" title="<spring:message code="addTopic.optional.title"/>">
-                                <form:radiobutton path="subscriptionMethod" value="3"/>
+                                <form:radiobutton role="radio" path="subscriptionMethod" value="3"/>
 																<spring:message code="addTopic.optional"/>
                             </label>
                         </div>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -209,7 +209,7 @@
                                 <td>
                                     <c:choose> 
                                         <c:when test="${topic.subscriptionMethod != 4}">
-                                            <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"></a>
+                                            <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"/></a>
                                         </c:when>
                                         <c:otherwise>
                                             <spring:message code="baseAdmin.no.actions"/>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -112,10 +112,10 @@
             <div class="nav-links">
                 <c:if test="${portalAdmin}">
                     <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/></portlet:renderURL>">
-                        <i class="fa fa-plus"></i> <spring:message code="baseAdmin.addnew"/></a> |
+                        <i class="fa fa-plus" aria-hidden="true"></i> <spring:message code="baseAdmin.addnew"/></a> |
                 </c:if>
                 <a href="<portlet:renderURL portletMode='HELP' windowState='MAXIMIZED'/>">
-                    <i class="fa fa-question-circle"></i> <spring:message code="baseAdmin.help"/>
+                    <i class="fa fa-question-circle" aria-hidden="true"></i> <spring:message code="baseAdmin.help"/>
                 </a>
             </div>
         </div>
@@ -163,10 +163,10 @@
                                             <table>
                                                 <tr>
                                                     <td>                                     
-                                                        <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"></i> <spring:message code="baseAdmin.edit"/></a>
+                                                        <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit" aria-hidden="true"></i> <spring:message code="baseAdmin.edit"/></a>
                                                     </td>
                                                     <td>
-                                                        <a class="action-icon" href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="baseAdmin.delete"/>"><i class="fa fa-trash-o"></i> <spring:message code="baseAdmin.delete"/></a>
+                                                        <a class="action-icon" href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="baseAdmin.delete"/>"><i class="fa fa-trash-o" aria-hidden="true"></i> <spring:message code="baseAdmin.delete"/></a>
                                                     </td>
                                                 </tr>
                                             </table>
@@ -253,7 +253,7 @@
     <c:if test="${pendingAnnouncementCount > 0}">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-12 no-col-padding">
-                <h4><i class="fa fa-thumbs-up"></i> <spring:message code="baseAdmin.myapprovals"/></h4>
+                <h4><i class="fa fa-thumbs-up" aria-hidden="true"></i> <spring:message code="baseAdmin.myapprovals"/></h4>
             </div>
         </div>
         <div class="row">
@@ -272,8 +272,8 @@
                                         <span class="anc-topic"><c:out value="${announcement.parent.title}"/></span>
                                     </td>
                                     <td class="text-right" width="25%">
-                                        <a class="anc-approve" href="<portlet:renderURL/>" onclick="javascript:${n}approval(this,${announcement.parent.id},${announcement.id});return false;;"><i class="fa fa-check-square"></i>  <span><spring:message code="baseAdmin.approve"/></span></a> |
-                                        <a class="anc-edit" href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${announcement.id}"/></portlet:renderURL>"><i class="fa fa-pencil"></i> <span><spring:message code="baseAdmin.edit"/></span></a>
+                                        <a class="anc-approve" href="<portlet:renderURL/>" onclick="javascript:${n}approval(this,${announcement.parent.id},${announcement.id});return false;;"><i class="fa fa-check-square" aria-hidden="true"></i>  <span><spring:message code="baseAdmin.approve"/></span></a> |
+                                        <a class="anc-edit" href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${announcement.id}"/></portlet:renderURL>"><i class="fa fa-pencil" aria-hidden="true"></i> <span><spring:message code="baseAdmin.edit"/></span></a>
                                     </td>
                                 </tr>
                             </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -115,7 +115,7 @@
                         <i class="fa fa-plus"></i> <spring:message code="baseAdmin.addnew"/></a> |
                 </c:if>
                 <a href="<portlet:renderURL portletMode='HELP' windowState='MAXIMIZED'/>">
-                    <i class="fa fa-question-circle"></i>
+                    <i class="fa fa-question-circle"></i> <spring:message code="baseAdmin.help"/>
                 </a>
             </div>
         </div>
@@ -152,23 +152,29 @@
                                         <c:when test="${topic.subscriptionMethod == 3}">
                                             <spring:message code="addTopic.optional"/>
                                         </c:when>
+                                        <c:otherwise>
+                                            <spring:message code="baseAdmin.no.subMethod"/>
+                                        </c:otherwise>
                                     </c:choose>
                                 </td>
                                 <td>
-                                    <table class="action-icon-table">
-                                        <tr>
-                                            <td>
-                                                <c:if test="${topic.subscriptionMethod != 4}">
-                                                    <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"></i></a>
-                                                </c:if>
-                                            </td>
-                                            <td>
-                                                <c:if test="${topic.subscriptionMethod != 4}">
-                                                    <a class="action-icon" href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="baseAdmin.delete"/>"><i class="fa fa-trash-o"></i></a>
-                                                </c:if>
-                                            </td>
-                                        </tr>
-                                    </table>
+                                    <c:choose>
+                                        <c:when test="${topic.subscriptionMethod != 4}">
+                                            <table>
+                                                <tr>
+                                                    <td>                                     
+                                                        <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"></i> <spring:message code="baseAdmin.edit"/></a>
+                                                    </td>
+                                                    <td>
+                                                        <a class="action-icon" href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteTopic"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="baseAdmin.delete"/>"><i class="fa fa-trash-o"></i> <spring:message code="baseAdmin.delete"/></a>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <spring:message code="baseAdmin.no.actions"/>
+                                        </c:otherwise>
+                                    </c:choose>
                                 </td>
                             </tr>
                         </c:forEach>
@@ -195,13 +201,20 @@
                                         <c:when test="${topic.subscriptionMethod == 3}">
                                             <spring:message code="addTopic.optional"/>
                                         </c:when>
+                                        <c:otherwise>
+                                            <spring:message code="baseAdmin.no.subMethod"/>
+                                        </c:otherwise>
                                     </c:choose>
                                 </td>
                                 <td>
-                                    <c:if test="${topic.subscriptionMethod != 4}">
-                                        <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><img src="<c:url value="/icons/pencil.png"/>" height="16" width="16" border="0" alt="<spring:message code="baseAdmin.edit"/>"/></a>&nbsp;&nbsp;
-                                    </c:if>
-                                    &nbsp;
+                                    <c:choose> 
+                                        <c:when test="${topic.subscriptionMethod != 4}">
+                                            <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"></a>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <spring:message code="baseAdmin.no.actions"/>
+                                        </c:otherwise>
+                                    </c:choose>
                                 </td>
                             </tr>
                         </c:forEach>
@@ -223,6 +236,9 @@
                                         </c:when>
                                         <c:when test="${topic.subscriptionMethod == 3}">
                                             <spring:message code="addTopic.optional"/>
+                                        </c:when>
+                                        <c:when test="${topic.subscriptionMethod == 4}">
+                                            <spring:message code="baseAdmin.no.subMethod"/>
                                         </c:when>
                                     </c:choose>
                                 </td>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -123,11 +123,12 @@
     <div class="row">
         <div class="col-md-12">
             <table class="table table-condensed announcements-table">
+                <caption class="sr-only"><spring:message code="baseAdmin.table"/></caption>
                 <thead>
-                    <th><spring:message code="baseAdmin.header.topics"/></th>
-                    <th><spring:message code="baseAdmin.header.status"/></th>
-                    <th><spring:message code="baseAdmin.header.subscriptionmethod"/></th>
-                    <th><spring:message code="baseAdmin.header.actions"/></th>
+                    <th scope="col"><spring:message code="baseAdmin.header.topics"/></th>
+                    <th scope="col"><spring:message code="baseAdmin.header.status"/></th>
+                    <th scope="col"><spring:message code="baseAdmin.header.subscriptionmethod"/></th>
+                    <th scope="col"><spring:message code="baseAdmin.header.actions"/></th>
                 </thead>
                 <c:choose><%-- Needs refactoring... nor reason for 3 loops --%>
                     <c:when test="${portalAdmin}">
@@ -160,7 +161,7 @@
                                 <td>
                                     <c:choose>
                                         <c:when test="${topic.subscriptionMethod != 4}">
-                                            <table>
+                                            <table role="presentation">
                                                 <tr>
                                                     <td>                                     
                                                         <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit" aria-hidden="true"></i> <spring:message code="baseAdmin.edit"/></a>
@@ -262,7 +263,7 @@
                     <span id="${n}approval_count" class="approval-count"><c:out value="${pendingAnnouncementCount}"/></span>
                     <a class="anc-approval-list-toggle" href="#"><spring:message code="baseAdmin.waitingapproval"/></a>
                     <div class="anc-my-approvals hide">
-                        <table class="anc-approval-list table table-condensed">
+                        <table class="anc-approval-list table table-condensed" role="presentation">
                             <c:forEach items="${pendingAnnouncements}" var="announcement">
                                 <tr>
                                     <td>

--- a/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
@@ -111,9 +111,9 @@
         <div class="col-md-12 no-col-padding">
             <div class="nav-links">
                 <c:if test="${not isGuest && not disableEdit}">
-                    <a href="<portlet:renderURL portletMode="edit" />"><i class="fa fa-edit"></i> <spring:message code="display.link.edit"/></a>
+                    <a href="<portlet:renderURL portletMode="edit" />"><i class="fa fa-edit" aria-hidden="true"></i> <spring:message code="display.link.edit"/></a>
                 </c:if> |
-                <a href="<portlet:renderURL><portlet:param name="action" value="displayHistory"/></portlet:renderURL>"><i class="fa fa-archive"></i> <spring:message code="display.link.history"/></a>
+                <a href="<portlet:renderURL><portlet:param name="action" value="displayHistory"/></portlet:renderURL>"><i class="fa fa-archive" aria-hidden="true"></i> <spring:message code="display.link.history"/></a>
             </div>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
@@ -61,7 +61,7 @@
     <div class="container-fluid bootstrap-styles announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="nav-links">
-                <a href="<portlet:renderURL />"><i class="fa fa-arrow-left"></i> <spring:message code="displayFull.back"/></a>
+                <a href="<portlet:renderURL />"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="displayFull.back"/></a>
             </div>
         </div>
         <div class="ann-display-item-full">

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -28,7 +28,7 @@
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-12 no-col-padding">
                 <div class="nav-links">
-                    <a href="<portlet:renderURL />"><i class="fa fa-arrow-left"></i> <spring:message code="display.back"/></a>
+                    <a href="<portlet:renderURL />"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="display.back"/></a>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -37,12 +37,13 @@
                 <div class="row">
                     <div class="ann-user-archive-table col-md-12">
                         <table id="historyTable" class="table table-condensed announcements-table">
+                            <caption class="sr-only"><spring:message code="display.table"/></caption>
                             <thead>
                                 <tr>
-                                    <th width="15%"><spring:message code="display.header.topic"/></th>
-                                    <th><spring:message code="display.header.ann"/></th>
-                                    <th><spring:message code="display.header.start"/></th>
-                                    <th><spring:message code="display.header.end"/></th>
+                                    <th scope="col" width="15%"><spring:message code="display.header.topic"/></th>
+                                    <th scope="col"><spring:message code="display.header.ann"/></th>
+                                    <th scope="col"><spring:message code="display.header.start"/></th>
+                                    <th scope="col"><spring:message code="display.header.end"/></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -32,34 +32,41 @@
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="ann-user-archive-table col-md-12">
-                <table id="historyTable" class="table table-condensed announcements-table">
-                    <thead>
-                        <tr>
-                            <th width="15%"><spring:message code="display.header.topic"/></th>
-                            <th><spring:message code="display.header.ann"/></th>
-                            <th><spring:message code="display.header.start"/></th>
-                            <th><spring:message code="display.header.end"/></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <c:forEach items="${announcements}" var="announcement" varStatus="status">
-                            <tr>
-                                <td><c:out value="${announcement.parent.title}"/></td>
-                                <td>
-                                    <p><a title="<spring:message code="display.title.fullannouncement"/>" href="<portlet:renderURL><portlet:param name="action" value="displayFullAnnouncementHistory"/><portlet:param name="announcementId" value="${announcement.id}"/></portlet:renderURL>"><c:out value="${announcement.title}"/></a></p>
-                                    <p><c:out value="${announcement.abstractText}"/></p>
-                                    <c:if test="${not empty announcement.link}">
-                                        <p><spring:message code="display.link.prefix"/> <a href="<c:out value="${announcement.link}"/>"><c:out value="${announcement.link}"/></a></p>
-                                    </c:if>
-                                </td>
-                                <td><p><fmt:formatDate value="${announcement.startDisplay}" dateStyle="medium"/></p></td>
-                                <td><p><fmt:formatDate value="${announcement.endDisplay}" dateStyle="medium"/></p></td>
-                            </tr>
-                        </c:forEach>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        <c:choose>
+            <c:when test="${not empty announcements}">
+                <div class="row">
+                    <div class="ann-user-archive-table col-md-12">
+                        <table id="historyTable" class="table table-condensed announcements-table">
+                            <thead>
+                                <tr>
+                                    <th width="15%"><spring:message code="display.header.topic"/></th>
+                                    <th><spring:message code="display.header.ann"/></th>
+                                    <th><spring:message code="display.header.start"/></th>
+                                    <th><spring:message code="display.header.end"/></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <c:forEach items="${announcements}" var="announcement" varStatus="status">
+                                    <tr>
+                                        <td><c:out value="${announcement.parent.title}"/></td>
+                                        <td>
+                                            <p><a title="<spring:message code="display.title.fullannouncement"/>" href="<portlet:renderURL><portlet:param name="action" value="displayFullAnnouncementHistory"/><portlet:param name="announcementId" value="${announcement.id}"/></portlet:renderURL>"><c:out value="${announcement.title}"/></a></p>
+                                            <p><c:out value="${announcement.abstractText}"/></p>
+                                            <c:if test="${not empty announcement.link}">
+                                                <p><spring:message code="display.link.prefix"/> <a href="<c:out value="${announcement.link}"/>"><c:out value="${announcement.link}"/></a></p>
+                                            </c:if>
+                                        </td>
+                                        <td><p><fmt:formatDate value="${announcement.startDisplay}" dateStyle="medium"/></p></td>
+                                        <td><p><fmt:formatDate value="${announcement.endDisplay}" dateStyle="medium"/></p></td>
+                                    </tr>
+                                </c:forEach>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </c:when>
+            <c:otherwise>
+                <div class="col-lg-12 alert alert-warning"><spring:message code="display.no.history"/></div>
+            </c:otherwise>
+        </c:choose>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -51,20 +51,20 @@
                                         <td>
                                             <c:choose>
                                                 <c:when test="${ts.topic.subscriptionMethod == 1}">
-                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" disabled="disabled" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
+                                                    <input role="checkbox" aria-labelledby="${ts.topic.title}" type="checkbox" disabled="disabled" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
                                                 </c:when>
                                                 <c:when test="${ts.topic.subscriptionMethod != 1 and ts.subscribed}">
-                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
+                                                    <input role="checkbox" aria-labelledby="${ts.topic.title}" type="checkbox" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
                                                 </c:when>
                                                 <c:when test="${ts.topic.subscriptionMethod != 1 and not ts.subscribed}">
-                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" value="true" name="subscribed_${status.index}" aria-checked="false"/>
+                                                    <input role="checkbox" aria-labelledby="${ts.topic.title}" type="checkbox" value="true" name="subscribed_${status.index}" aria-checked="false"/>
                                                 </c:when>
                                             </c:choose>
                                             <input type="hidden" name="topicId_${status.index}" value="${ts.topic.id}"/>
                                             <input type="hidden" name="topicSubId_${status.index}" value="${ts.id}"/>
                                         </td>
                                         <td>
-                                            <label id="SubscriptionName"><c:out value="${ts.topic.title}"/></label>
+                                            <label id="${ts.topic.title}"><c:out value="${ts.topic.title}"/></label>
                                         </td>
                                         <td>
                                             <c:out value="${ts.topic.description}"/>

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -35,7 +35,7 @@
             <div class="col-md-6 no-col-padding">
                 <div class="nav-links">
                     <c:if test="${isGuest}">
-                        <a href="<portlet:renderURL portletMode="view"></portlet:renderURL>"><i class="fa fa-arrow-left"></i> <spring:message code="edit.back"/></a>
+                        <a href="<portlet:renderURL portletMode="view"></portlet:renderURL>"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="edit.back"/></a>
                     </c:if>
                 </div>
             </div>

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -51,20 +51,20 @@
                                         <td>
                                             <c:choose>
                                                 <c:when test="${ts.topic.subscriptionMethod == 1}">
-                                                    <input type="checkbox" disabled="disabled" checked="checked" value="true" name="subscribed_${status.index}"/>
+                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" disabled="disabled" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
                                                 </c:when>
                                                 <c:when test="${ts.topic.subscriptionMethod != 1 and ts.subscribed}">
-                                                    <input type="checkbox" checked="checked" value="true" name="subscribed_${status.index}"/>
+                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" checked="checked" value="true" name="subscribed_${status.index}" aria-checked="true"/>
                                                 </c:when>
                                                 <c:when test="${ts.topic.subscriptionMethod != 1 and not ts.subscribed}">
-                                                    <input type="checkbox" value="true" name="subscribed_${status.index}"/>
+                                                    <input role="checkbox" aria-labelledby="SubscriptionName" type="checkbox" value="true" name="subscribed_${status.index}" aria-checked="false"/>
                                                 </c:when>
                                             </c:choose>
                                             <input type="hidden" name="topicId_${status.index}" value="${ts.topic.id}"/>
                                             <input type="hidden" name="topicSubId_${status.index}" value="${ts.id}"/>
                                         </td>
                                         <td>
-                                            <c:out value="${ts.topic.title}"/>
+                                            <label id="SubscriptionName"><c:out value="${ts.topic.title}"/></label>
                                         </td>
                                         <td>
                                             <c:out value="${ts.topic.description}"/>
@@ -112,12 +112,12 @@
                 <div class="col-md-12">
                     <c:choose>
                         <c:when test="${not prefHideAbstract}">
-                            <input type="checkbox" value="true" name="hideAbstract"/>
-                            <label><spring:message code="edit.pref.hideabstract"/></label>
+                            <input role="checkbox" aria-labelledby="HideAbstract" type="checkbox" value="true" name="hideAbstract"/>
+                            <label id="HideAbstract"><spring:message code="edit.pref.hideabstract"/></label>
                         </c:when>
                         <c:otherwise>
-                            <input type="checkbox" value="true" name="hideAbstract" checked="checked"/>
-                            <label><spring:message code="edit.pref.hideabstract"/></label>
+                            <input role="checkbox" aria-labelledby="HideAbstract" type="checkbox" value="true" name="hideAbstract" checked="checked"/>
+                            <label id="HideAbstract"><spring:message code="edit.pref.hideabstract"/></label>
                         </c:otherwise>
                     </c:choose>
                 </div>

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -43,7 +43,7 @@
         <form action="${actionUrl}" method="post" role="form">
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
-                    <table class="table table-condensed announcements-table">
+                    <table role="presentation" class="table table-condensed announcements-table">
                         <c:forEach items="${topicSubscriptions}" var="ts" varStatus="status">
                             <c:choose>
                                 <c:when test="${not isGuest}">

--- a/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -156,4 +156,6 @@
 For more details visit the AnnouncementsPortlet <a href="https://wiki.jasig.org/display/PLT/Announcements+Portlet" target="_blank">wiki page</a>.
 
 <br/><br/>
-<a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"/>"><img src="<c:url value="/icons/arrow_left.png"/>" border="0" height="16" width="16" style="vertical-align:middle"/> <spring:message code="general.adminhome"/></a>
+<div class="nav-links">
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"/>"><i class="fa fa-arrow-left"></i><spring:message code="general.adminhome"/></a>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -157,5 +157,5 @@ For more details visit the AnnouncementsPortlet <a href="https://wiki.jasig.org/
 
 <br/><br/>
 <div class="nav-links">
-    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"/>"><i class="fa fa-arrow-left"></i><spring:message code="general.adminhome"/></a>
+    <a style="text-decoration:none;font-size:0.9em;" href="<portlet:renderURL portletMode="view" windowState="normal"/>"><i class="fa fa-arrow-left" aria-hidden="true"> </i><spring:message code="general.adminhome"/></a>
 </div>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -33,8 +33,8 @@
             </div>
             <div class="col-md-6 no-col-padding">
                 <div class="nav-links">
-                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${ topic.id }"/></portlet:renderURL>"><i class="fa fa-arrow-left"></i> <spring:message code="general.backtotopic"/></a> |
-                    <a href="<portlet:renderURL></portlet:renderURL>"><i class="fa fa-home"></i> <spring:message code="general.adminhome"/></a>
+                    <a href="<portlet:renderURL><portlet:param name="action" value="showTopic"/><portlet:param name="topicId" value="${ topic.id }"/></portlet:renderURL>"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="general.backtotopic"/></a> |
+                    <a href="<portlet:renderURL></portlet:renderURL>"><i class="fa fa-home" aria-hidden="true"></i> <spring:message code="general.adminhome"/></a>
                 </div>
             </div>
         </div>
@@ -60,8 +60,8 @@
                                         <td><a title="<spring:message code="showHistory.preview"/>"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a><br /><c:out value="${ann.abstractText}"/></td>
                                         <td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/></td>
                                         <td><fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
-                                        <td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>"><span class="pull-right"><spring:message code="showHistory.viewedit"/> <i class="fa fa-edit"></i></span></a></td>
-                                        <td><a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>"><span class="pull-right"><spring:message code="showHistory.delete"/> <i class="fa fa-trash-o"></i></span></a></td>
+                                        <td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>"><span class="pull-right"><spring:message code="showHistory.viewedit"/> <i class="fa fa-edit" aria-hidden="true"></i></span></a></td>
+                                        <td><a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>"><span class="pull-right"><spring:message code="showHistory.delete"/> <i class="fa fa-trash-o" aria-hidden="true"></i></span></a></td>
                                     </tr>
                                 </c:forEach>
                             </tbody>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -57,11 +57,28 @@
                                 <c:forEach items="${announcements}" var="ann">
                                     <tr>
                                         <td><c:out value="${ann.parent.title}"/></td>
-                                        <td><a title="<spring:message code="showHistory.preview"/>"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a><br /><c:out value="${ann.abstractText}"/></td>
+                                        <td>
+                                            <a title="<spring:message code="showHistory.preview"/>"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>">
+                                                <c:out value="${ann.title}"/>
+                                            </a>
+                                            <br/><c:out value="${ann.abstractText}"/>
+                                        </td>
                                         <td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/></td>
                                         <td><fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
-                                        <td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>"><span class="pull-right"><spring:message code="showHistory.viewedit"/> <i class="fa fa-edit" aria-hidden="true"></i></span></a></td>
-                                        <td><a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>"><span class="pull-right"><spring:message code="showHistory.delete"/> <i class="fa fa-trash-o" aria-hidden="true"></i></span></a></td>
+                                        <td>
+                                            <a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>">
+                                                <span class="pull-right">
+                                                    <spring:message code="showHistory.viewedit"/> <i class="fa fa-edit" aria-hidden="true"></i>
+                                                </span>
+                                            </a>
+                                        </td>
+                                        <td>
+                                            <a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>">
+                                                <span class="pull-right">
+                                                    <spring:message code="showHistory.delete"/> <i class="fa fa-trash-o" aria-hidden="true"></i>
+                                                </span>
+                                            </a>
+                                        </td>
                                     </tr>
                                 </c:forEach>
                             </tbody>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -38,34 +38,41 @@
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="col-md-12">
-                <table id="historyTable" class="table table-condensed announcements-table tablesorter">
-                    <thead>
-                        <tr>
-                            <th width="15%"><spring:message code="showHistory.header.topic"/></th>
-                            <th><spring:message code="showHistory.header.ann"/></th>
-                            <th><spring:message code="showHistory.header.start"/></th>
-                            <th><spring:message code="showHistory.header.end"/></th>
-                            <th><spring:message code="showHistory.header.repost"/></th>
-                            <th><spring:message code="showHistory.header.delete"/></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <c:forEach items="${announcements}" var="ann">
-                            <tr>
-                                <td><c:out value="${ann.parent.title}"/></td>
-                                <td><a title="<spring:message code="showHistory.preview"/>"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a><br /><c:out value="${ann.abstractText}"/></td>
-                                <td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/></td>
-                                <td><fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
-                                <td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>"><span class="pull-right"><i class="fa fa-edit"></i></span></a></td>
-                                <td><a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>"><span class="pull-right"><i class="fa fa-trash-o"></i></span></a></td>
-                            </tr>
-                        </c:forEach>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        <c:choose>
+            <c:when test="${not empty announcements}">
+                <div class="row">
+                    <div class="col-md-12">
+                        <table id="historyTable" class="table table-condensed announcements-table tablesorter">
+                            <thead>
+                                <tr>
+                                    <th width="15%"><spring:message code="showHistory.header.topic"/></th>
+                                    <th><spring:message code="showHistory.header.ann"/></th>
+                                    <th><spring:message code="showHistory.header.start"/></th>
+                                    <th><spring:message code="showHistory.header.end"/></th>
+                                    <th><spring:message code="showHistory.header.repost"/></th>
+                                    <th><spring:message code="showHistory.header.delete"/></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <c:forEach items="${announcements}" var="ann">
+                                    <tr>
+                                        <td><c:out value="${ann.parent.title}"/></td>
+                                        <td><a title="<spring:message code="showHistory.preview"/>"  href="<portlet:renderURL><portlet:param name="action" value="previewAnnouncement"/><portlet:param name="annId" value="${ ann.id }"/></portlet:renderURL>"><c:out value="${ann.title}"/></a><br /><c:out value="${ann.abstractText}"/></td>
+                                        <td><fmt:formatDate value="${ann.startDisplay}" dateStyle="short"/></td>
+                                        <td><fmt:formatDate value="${ann.endDisplay}" dateStyle="short"/></td>
+                                        <td><a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="editId" value="${ann.id}"/></portlet:renderURL>" title="<spring:message code="showHistory.viewedit"/>"><span class="pull-right"><spring:message code="showHistory.viewedit"/> <i class="fa fa-edit"></i></span></a></td>
+                                        <td><a href="#" onclick="${n}_delete('<portlet:actionURL escapeXml="false"><portlet:param name="action" value="deleteAnnouncement"/><portlet:param name="annId" value="${ann.id}"/><portlet:param name="topicId" value="${topic.id}"/></portlet:actionURL>');" title="<spring:message code="showHistory.delete"/>"><span class="pull-right"><spring:message code="showHistory.delete"/> <i class="fa fa-trash-o"></i></span></a></td>
+                                    </tr>
+                                </c:forEach>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </c:when>
+            <c:otherwise>
+                <div class="col-lg-12 alert alert-warning"><spring:message code="display.no.history"/></div>
+            </c:otherwise>
+        </c:choose>
     </div>
 
 

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -43,14 +43,15 @@
                 <div class="row">
                     <div class="col-md-12">
                         <table id="historyTable" class="table table-condensed announcements-table tablesorter">
+                            <caption class="sr-only"><spring:message code="showHistory.table"/></caption>
                             <thead>
                                 <tr>
-                                    <th width="15%"><spring:message code="showHistory.header.topic"/></th>
-                                    <th><spring:message code="showHistory.header.ann"/></th>
-                                    <th><spring:message code="showHistory.header.start"/></th>
-                                    <th><spring:message code="showHistory.header.end"/></th>
-                                    <th><spring:message code="showHistory.header.repost"/></th>
-                                    <th><spring:message code="showHistory.header.delete"/></th>
+                                    <th scope="col" width="15%"><spring:message code="showHistory.header.topic"/></th>
+                                    <th scope="col"><spring:message code="showHistory.header.ann"/></th>
+                                    <th scope="col"><spring:message code="showHistory.header.start"/></th>
+                                    <th scope="col"><spring:message code="showHistory.header.end"/></th>
+                                    <th scope="col"><spring:message code="showHistory.header.repost"/></th>
+                                    <th scope="col"><spring:message code="showHistory.header.delete"/></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -108,7 +108,7 @@
                             <th><spring:message code="show.head.status"/></th>
                             <th width="50%"><spring:message code="show.head.title"/></th>
                             <th><spring:message code="show.head.displaying"/></th>
-                            <th></th>
+                            <th><spring:message code="show.head.actions"/></th>
                         </thead>
                         <tbody>
                             <c:forEach items="${announcements}" var="ann">

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -87,8 +87,8 @@
         </div>
         <div class="col-md-6 no-col-padding">
             <div class="nav-links">
-                <a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><i class="fa fa-plus"></i> <spring:message code="show.addAnn"/></a> |
-                <a href="<portlet:renderURL></portlet:renderURL>"><i class="fa fa-home"></i> <spring:message code="general.adminhome"/></a>
+                <a href="<portlet:renderURL><portlet:param name="action" value="addAnnouncement"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><i class="fa fa-plus" aria-hidden="true"></i> <spring:message code="show.addAnn"/></a> |
+                <a href="<portlet:renderURL></portlet:renderURL>"><i class="fa fa-home" aria-hidden="true"></i> <spring:message code="general.adminhome"/></a>
             </div>
         </div>
     </div>
@@ -171,7 +171,7 @@
     </div>
     <div class="row">
         <div class="col-md-12">
-            <a class="btn btn-default btn-xs pull-right" href="<portlet:renderURL><portlet:param name="action" value="showHistory"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><spring:message code="show.history"/> <i class="fa fa-archive"></i></a>
+            <a class="btn btn-default btn-xs pull-right" href="<portlet:renderURL><portlet:param name="action" value="showHistory"/><portlet:param name="topicId" value="${topic.id}"/></portlet:renderURL>"><spring:message code="show.history"/> <i class="fa fa-archive" aria-hidden="true"></i></a>
         </div>
     </div>
     <c:if test="${user.admin}">

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -95,6 +95,7 @@
     <div class="row">
         <div class="col-md-12">
             <table class="table table-condensed announcements-table">
+                <caption class="sr-only"><spring:message code="show.table"/></caption>
                 <c:choose>
                     <c:when test="${empty announcements}">
                         <tr>
@@ -105,10 +106,10 @@
                     </c:when>
                     <c:otherwise>
                         <thead>
-                            <th><spring:message code="show.head.status"/></th>
-                            <th width="50%"><spring:message code="show.head.title"/></th>
-                            <th><spring:message code="show.head.displaying"/></th>
-                            <th><spring:message code="show.head.actions"/></th>
+                            <th scope="col"><spring:message code="show.head.status"/></th>
+                            <th scope="col" width="50%"><spring:message code="show.head.title"/></th>
+                            <th scope="col"><spring:message code="show.head.displaying"/></th>
+                            <th scope="col"><spring:message code="show.head.actions"/></th>
                         </thead>
                         <tbody>
                             <c:forEach items="${announcements}" var="ann">

--- a/src/main/webapp/less/includes/_base.less
+++ b/src/main/webapp/less/includes/_base.less
@@ -65,7 +65,6 @@
             .action-icon {
                 padding: 6px;
             }
-
         }
     }
 
@@ -174,6 +173,5 @@
     .no-col-padding {
         padding: 0;
     }
-
 }
 

--- a/src/main/webapp/less/includes/_base.less
+++ b/src/main/webapp/less/includes/_base.less
@@ -39,6 +39,10 @@
 //@import "_variables.less";
 
 .announcements-container {
+    a {
+        color: #0074b7;
+    }
+
     .announcements-portlet-toolbar {
         border-bottom: 1px solid @color1-light;
         margin: 0 0 10px 0;
@@ -121,9 +125,22 @@
     .ann-display-item-summary {
         border-bottom: 1px solid #eee;
     }
+
     .announcement-list-nav {
         margin-top: 10px;
         margin-bottom: 10px;
+    }
+
+    .btn-primary{
+        background-color: #0074b7;
+    }
+
+    .btn-link{
+        color: #0074b7
+    }
+
+    .label-danger{
+        background-color: #852500;
     }
 
     .permissions-group-padding {
@@ -152,5 +169,6 @@
     .no-col-padding {
         padding: 0;
     }
+
 }
 

--- a/src/main/webapp/less/includes/_base.less
+++ b/src/main/webapp/less/includes/_base.less
@@ -99,6 +99,11 @@
           border: 1px solid #ccc;
           padding: 6px 12px;
         }
+        legend {
+            font-size: 14px;
+            border: none;
+            font-weight: bold;
+        }
     }
 
     .ann-display-item-summary, .ann-display-item-full {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
https://issues.jasig.org/browse/ANNPLT-128

- Link text color throughout portlet violates ADA by having a low contrast with background.
- The color of dark red warnings (danger-label) does not have sufficient contrast with its text for ADA standards.
- Table headers need to have content under them for ADA compliance. Tables in this portlet are capable of being empty and therefore create violations.
- There are a set of radio buttons without ADA roles in topic creation.
- There are a few unlabeled checkboxes in the user edit view. Checkboxes need to have a form label for ADA compliance.
- Links must have link text. The help link, edit link, and delete link in the base admin all have no text associated with them.
- Image on the back button in admin help has no alt text.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
