### PR TITLE
ANNPLT-129:  Drop the hibernate3-maven-plugin in favor of providing d…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,13 @@
             <version>3.6.10.Final</version>
         </dependency>
 
+        <!-- Needed for schema reset;  version compatible with org.hibernate:hibernate-core:3.6.10.FINAL -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-tools</artifactId>
+            <version>3.6.0.Final</version>
+        </dependency>
+
         <dependency><!-- java bytecode processor required by hibernate-->
             <groupId>javassist</groupId>
             <artifactId>javassist</artifactId>
@@ -429,35 +436,47 @@
                 <!-- extensions must be set to true to pick up the custom phases -->
                 <extensions>true</extensions>
             </plugin>
+            <!--
+             | Invoke this plugin as follows to drop and recreate the Announcements database tables...
+             |
+             |   >mvn db-init
+             +-->
             <plugin>
-                <!--
-                 | Invoke this plugin as follows to drop and recreate the Announcements database tables...
-                 |
-                 |   >mvn db-init
-                 +-->
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>hibernate3-maven-plugin</artifactId>
-                <version>2.2</version>
+                <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>schema-create</id>
                         <phase>db-init</phase>
                         <goals>
-                            <goal>hbm2ddl</goal>
+                            <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="runtime_classpath" refid="maven.runtime.classpath" />
+                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
+
+                                <java failonerror="true" classname="org.jasig.portlet.announcements.SchemaCreator">
+                                    <sysproperty key="log4j.configuration" value="command-line.log4j.properties" />
+                                    <classpath>
+                                        <pathelement location="${project.build.directory}/${project.artifactId}/WEB-INF/context" />
+                                        <pathelement path="${runtime_classpath}" />
+                                        <pathelement path="${plugin_classpath}" />
+                                    </classpath>
+                                </java>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <componentProperties>
-                        <propertyfile>target/${project.artifactId}/WEB-INF/classes/datasource.properties</propertyfile>
-                        <drop>true</drop>
-                    </componentProperties>
-                </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>${jdbc.groupId}</groupId>
-                        <artifactId>${jdbc.artifactId}</artifactId>
-                        <version>${jdbc.version}</version>
-                        <scope>compile</scope>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                        <version>${servlet-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.portlet</groupId>
+                        <artifactId>portlet-api</artifactId>
+                        <version>2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
@@ -15,6 +15,7 @@
 
 package org.jasig.portlet.announcements;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -76,9 +77,9 @@ public class SchemaCreator implements ApplicationContextAware {
                 .getBean(SESSION_FACTORY_BEAN_NAME, LocalSessionFactoryBean.class);
         final DataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, DataSource.class);
 
-        try {
+        try (final Connection conn = dataSource.getConnection()) {
             final Configuration cfg = sessionFactoryBean.getConfiguration();
-            final SchemaExport schemaExport = new SchemaExport(cfg, dataSource.getConnection());
+            final SchemaExport schemaExport = new SchemaExport(cfg, conn);
             schemaExport.execute(true, true, false, false);
 
             final List<Exception> exceptions = schemaExport.getExceptions();

--- a/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
@@ -18,7 +18,8 @@ package org.jasig.portlet.announcements;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import javax.sql.DataSource;
+
 import org.apache.log4j.Logger;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
@@ -73,7 +74,7 @@ public class SchemaCreator implements ApplicationContextAware {
 
         final LocalSessionFactoryBean sessionFactoryBean = applicationContext
                 .getBean(SESSION_FACTORY_BEAN_NAME, LocalSessionFactoryBean.class);
-        final BasicDataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, BasicDataSource.class);
+        final DataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, DataSource.class);
 
         try {
             final Configuration cfg = sessionFactoryBean.getConfiguration();

--- a/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/announcements/SchemaCreator.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jasig.portlet.announcements;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.log4j.Logger;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.jasig.portlet.announcements.spring.PortletApplicationContextLocator;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
+
+/**
+ * This tool is responsible for creating the Announcements portlet database schema (and dropping
+ * it first, if necessary).  It leverages the org.hibernate:hibernate-tools library, but integrates
+ * with Announcements' Spring-managed ORM strategy and Announcements' configuration features (esp.
+ * encrypted properties).  It is invokable from the command line with '$ java', but designed to be
+ * integrated with build tools like Gradle.
+ */
+public class SchemaCreator implements ApplicationContextAware {
+
+    /*
+     * Prefixing a Spring factory bean with '&' gives you the factory itself, rather than the product.
+     * (https://stackoverflow.com/questions/2736100/how-can-i-get-the-hibernate-configuration-object-from-spring)
+     */
+    private static final String SESSION_FACTORY_BEAN_NAME = "&sessionFactory";
+
+    private static final String DATA_SOURCE_BEAN_NAME = "dataSource";
+
+    private ApplicationContext applicationContext;
+
+    private final Logger logger = Logger.getLogger(getClass());
+
+    public static void main(String[] args) {
+
+        // There will be an instance of this class in the ApplicationContent
+        ApplicationContext context =
+                PortletApplicationContextLocator.getApplicationContext(
+                        PortletApplicationContextLocator.DATABASE_CONTEXT_LOCATION);
+        final SchemaCreator schemaCreator = context.getBean("schemaCreator", SchemaCreator.class);
+        System.exit(schemaCreator.create());
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    private int create() {
+
+        /*
+         * We will need to provide a Configuration and a Connection;  both should be properly
+         * managed by the Spring ApplicationContext.
+         */
+
+        final LocalSessionFactoryBean sessionFactoryBean = applicationContext
+                .getBean(SESSION_FACTORY_BEAN_NAME, LocalSessionFactoryBean.class);
+        final BasicDataSource dataSource = applicationContext.getBean(DATA_SOURCE_BEAN_NAME, BasicDataSource.class);
+
+        try {
+            final Configuration cfg = sessionFactoryBean.getConfiguration();
+            final SchemaExport schemaExport = new SchemaExport(cfg, dataSource.getConnection());
+            schemaExport.execute(true, true, false, false);
+
+            final List<Exception> exceptions = schemaExport.getExceptions();
+            if (exceptions.size() != 0) {
+                logger.error("Schema Create Failed;  see below for details");
+                for (Exception e : exceptions) {
+                    logger.error("Exception from Hibernate Tools SchemaExport", e);
+                }
+                return 1;
+            }
+        } catch (SQLException sqle) {
+            logger.error("Failed to initialize & invoke the SchemaExport tool", sqle);
+            return 1;
+        }
+
+        return 0;
+
+    }
+
+}

--- a/src/main/resources/context/databaseContext.xml
+++ b/src/main/resources/context/databaseContext.xml
@@ -122,4 +122,7 @@
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 
+    <!-- Used to [drop and] create the Announcements database schema from the command line -->
+    <bean id="schemaCreator" class="org.jasig.portlet.announcements.SchemaCreator" />
+
 </beans>


### PR DESCRIPTION
…irect support for database schema drop+create

https://issues.jasig.org/browse/ANNPLT-129

The Announcements portlet implements a 'db-init' Maven goal that drops & re-creates the database schema.  This capability is integrated into the uP4 Maven build via uportal-portlets-overlay.

The current implementation is based on the hibernate3-maven-plugin.  This solution is problematic because (1) it's not well integrated into the rest of the app's features (so it's always been very brittle), and (2) it doesn't port well to the Gradle-based build in uP5.

We need to  replace it with something we provide directly that *is* a first-class part of the Spring app.