### PR TITLE
ANNPLT-131:  Included Window's style exclusion patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -650,12 +650,15 @@
                     <schemaSourceExcludeFilters>
                       <limitIncludes implementation="org.codehaus.mojo.jaxb2.shared.filters.pattern.PatternFileFilter">
                         <patterns>
-                          <pattern>\/mvc\/.*\.java</pattern>
-                          <pattern>\/service\/.*\.java</pattern>
-                          <pattern>\/spring\/.*\.java</pattern>
-                          <pattern>Exporter\.java</pattern>
-                          <pattern>Importer\.java</pattern>
-                          <pattern>UnauthorizedException\.java</pattern>
+                            <pattern>\/mvc\/.*\.java</pattern>
+                            <pattern>\\mvc\\.*\.java</pattern>
+                            <pattern>\/service\/.*\.java</pattern>
+                            <pattern>\\service\\.*\.java</pattern>
+                            <pattern>\/spring\/.*\.java</pattern>
+                            <pattern>\\spring\\.*\.java</pattern>
+                            <pattern>Exporter\.java</pattern>
+                            <pattern>Importer\.java</pattern>
+                            <pattern>UnauthorizedException\.java</pattern>
                         </patterns>
                       </limitIncludes>
                     </schemaSourceExcludeFilters>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.14</version>
-            <type>jar</type>
         </dependency>
 
         <dependency>
@@ -659,11 +658,22 @@
                             <pattern>Exporter\.java</pattern>
                             <pattern>Importer\.java</pattern>
                             <pattern>UnauthorizedException\.java</pattern>
+                            <pattern>SchemaCreator\.java</pattern>
+                            <pattern>ApplicationContextConnectionProvider\.java</pattern>
+                            <pattern>AnnouncementValidator\.java</pattern>
+                            <pattern>TopicValidator\.java</pattern>
                         </patterns>
                       </limitIncludes>
                     </schemaSourceExcludeFilters>
                     <outputDirectory>target/generated-schemas</outputDirectory>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                        <version>1.2.14</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/jasig/portlet/announcements/model/AnnouncementConfiguration.java
+++ b/src/main/java/org/jasig/portlet/announcements/model/AnnouncementConfiguration.java
@@ -18,7 +18,7 @@
  */
 package org.jasig.portlet.announcements.model;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
+import java.util.Arrays;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
From https://issues.jasig.org/browse/ANNPLT-131

The Window's build was failing (in part) due to the file exclusion patterns not having Window's style slashes.  There's still more work on this however, the 'mvn clean install' command on Windows is failing with a generic NPE and running schemagen standalone only has some classpath errors.  might be the problem, however the classpath is similar to the schemagen classpath when run in Linux.