### PR TITLE
docs(readme): add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Apereo Announcements Portlet
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/Announcements/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/Announcements)
 [![Linux Build Status](https://travis-ci.org/Jasig/AnnouncementsPortlet.svg?branch=master)](https://travis-ci.org/Jasig/AnnouncementsPortlet)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/ckh2tqajlcxhepnr/branch/master?svg=true)](https://ci.appveyor.com/project/ChristianMurphy/announcementsportlet-wj0cf/branch/master)
 


### PR DESCRIPTION
Give at-a-glance knowledge of:
* latest version number
* that this is available from maven central
* link to documentation on inclusion for maven, gradle, etc