### PR TITLE
Refactor: use upstream bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ See also documentation in the [AnnouncementsPortlet wiki on Confluence][].
 
 ### Using Encrypted Property Values
 
-You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format.  Use the [Jasypt CLI Tools][] to encrypt the sensitive value, then include it in a `.properties` file like this:
+You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format. Use the [Jasypt CLI Tools][] to encrypt the sensitive value, then include it in a `.properties` file like this:
 
-``` ini
+```ini
 hibernate.connection.password=ENC(9ffpQXJi/EPih9o+Xshm5g==)
 ```
 
@@ -24,10 +24,13 @@ Specify the encryption key using the `UP_JASYPT_KEY` environment variable.
 
 These dependencies are expected to be loaded by overall uPortal:
 
-*   [Font Awesome][] 4, last tested with [Font Awesome 4.7.0][]
+* [Font Awesome][] 4, last tested with [Font Awesome 4.7.0][]
+* [Bootstrap][] 3, last tested with [Bootstrap 3.3.7][]
 
-[Sponsored Portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
-[AnnouncementsPortlet wiki on Confluence]: https://wiki.jasig.org/display/PLT/Announcements+Portlet
-[Font Awesome]: http://fontawesome.io/
-[Jasypt CLI Tools]: http://www.jasypt.org/cli.html
-[Font Awesome 4.7.0]: https://github.com/FortAwesome/Font-Awesome/releases/tag/v4.7.0
+[sponsored portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
+[announcementsportlet wiki on confluence]: https://wiki.jasig.org/display/PLT/Announcements+Portlet
+[font awesome]: http://fontawesome.io/
+[bootstrap]: https://getbootstrap.com
+[bootstrap 3.3.7]: https://getbootstrap.com/docs/3.3/
+[jasypt cli tools]: http://www.jasypt.org/cli.html
+[font awesome 4.7.0]: https://github.com/FortAwesome/Font-Awesome/releases/tag/v4.7.0

--- a/pom.xml
+++ b/pom.xml
@@ -441,8 +441,6 @@
                             <groupId>org.jasig.resourceserver</groupId>
                             <artifactId>resource-server-content</artifactId>
                             <includes>
-                                <include>rs/bootstrap-namespaced/3.1.1/</include>
-                                <include>rs/fontawesome/4.0.3/</include>
                                 <include>rs/jquery/1.11.0/</include>
                                 <include>rs/jquery-migrate/</include>
                                 <include>rs/jqueryui/1.10.3/</include>

--- a/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
@@ -126,7 +126,7 @@
     <portlet:param name="topicId" value="${announcement.parent.id}"/>
 </portlet:actionURL>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
                 <h4><spring:message code="addAnnouncement.header"/> <c:out value="${announcement.parent.title}"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addAnnouncement.jsp
@@ -26,7 +26,6 @@
 <script src="<rs:resourceURL value="/rs/jqueryui/1.10.3/jquery-ui-1.10.3.min.js"/>" type="text/javascript"></script>
 <script src="<c:url value="/js/underscore-min.js"/>" type="text/javascript"></script>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <script type="text/javascript" src="<c:url value="/tinymce/js/tinymce/tinymce.min.js"/>"></script>

--- a/src/main/webapp/WEB-INF/jsp/addMembers.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addMembers.jsp
@@ -32,7 +32,6 @@
 	<portlet:param name="groupKey" value="${groupKey}"/>
 </portlet:actionURL>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
     <div class="container-fluid bootstrap-styles announcements-container">

--- a/src/main/webapp/WEB-INF/jsp/addMembers.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addMembers.jsp
@@ -34,7 +34,7 @@
 
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
                 <h4 role="heading">

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -66,7 +66,7 @@
     }
     #tooltip h3, #tooltip div { margin: 0; }
 </style>
-<div class="container-fluid bootstrap-styles announcements-container">
+<div class="container-fluid announcements-container">
     <div class="row announcements-portlet-toolbar">
         <div class="col-md-8 no-col-padding">
             <h4>

--- a/src/main/webapp/WEB-INF/jsp/addTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/addTopic.jsp
@@ -25,7 +25,6 @@
 		<portlet:param name="action" value="addTopic"/>
 </portlet:actionURL>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <script src="<rs:resourceURL value="/rs/jquery/1.11.0/jquery-1.11.0.min.js"/>" type="text/javascript"></script>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -26,7 +26,6 @@
     <script type="text/javascript" src="<rs:resourceURL value="/rs/jquery-migrate/jquery-migrate-1.2.1.min.js"/>"></script>
     <script src="<rs:resourceURL value="/rs/jqueryui/1.10.3/jquery-ui-1.10.3.min.js"/>" type="text/javascript"></script>
 </c:if>
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css" />
 <link href="<c:url value="/css/announcements.css"/>" rel="stylesheet" type="text/css" />
 
 <c:if test="${portalAdmin}">
@@ -163,7 +162,7 @@
                                         <c:when test="${topic.subscriptionMethod != 4}">
                                             <table role="presentation">
                                                 <tr>
-                                                    <td>                                     
+                                                    <td>
                                                         <a class="action-icon" href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit" aria-hidden="true"></i> <spring:message code="baseAdmin.edit"/></a>
                                                     </td>
                                                     <td>
@@ -208,7 +207,7 @@
                                     </c:choose>
                                 </td>
                                 <td>
-                                    <c:choose> 
+                                    <c:choose>
                                         <c:when test="${topic.subscriptionMethod != 4}">
                                             <a href="<portlet:renderURL><portlet:param name="action" value="addTopic"/><portlet:param name="edit" value="${topic.id}"/></portlet:renderURL>" title="<spring:message code="baseAdmin.edit"/>"><i class="fa fa-edit"/></a>
                                         </c:when>

--- a/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/baseAdmin.jsp
@@ -105,7 +105,7 @@
     }
 </script>
 
-<div class="container-fluid bootstrap-styles announcements-container">
+<div class="container-fluid announcements-container">
     <div class="row announcements-portlet-toolbar">
         <div class="col-md-12 no-col-padding">
             <div class="nav-links">

--- a/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css" />
 <link href="<c:url value="/css/announcements.css"/>" rel="stylesheet" type="text/css" />
 
 <portlet:actionURL var="formUrl" escapeXml="false">

--- a/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
@@ -19,7 +19,6 @@
 
 --%>
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <c:set var="n"><portlet:namespace/></c:set>

--- a/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayAnnouncements.jsp
@@ -105,7 +105,7 @@
     </style>
 </c:if>
 
-<div id="${n}container" class="container-fluid bootstrap-styles announcements-container">
+<div id="${n}container" class="container-fluid announcements-container">
     <div class="row announcements-portlet-toolbar">
         <div class="col-md-12 no-col-padding">
             <div class="nav-links">

--- a/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
@@ -57,7 +57,7 @@
     });
 </script>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="nav-links">
                 <a href="<portlet:renderURL />"><i class="fa fa-arrow-left" aria-hidden="true"></i> <spring:message code="displayFull.back"/></a>

--- a/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayFullAnnouncement.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <script src="<rs:resourceURL value="/rs/jquery/1.11.0/jquery-1.11.0.min.js"/>" type="text/javascript"></script>

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
     <div class="container-fluid bootstrap-styles announcements-container">

--- a/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/displayHistory.jsp
@@ -23,7 +23,7 @@
 
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-12 no-col-padding">
                 <div class="nav-links">

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -26,7 +26,7 @@
 
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
                 <h4 role="heading"><spring:message code="edit.yoursubs"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editDisplayPreferences.jsp
@@ -24,7 +24,6 @@
 	<portlet:param name="action" value="editDisplayPreferences"/>
 </portlet:actionURL>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
     <div class="container-fluid bootstrap-styles announcements-container">

--- a/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -20,7 +20,6 @@
 --%>
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
     <div class="container-fluid bootstrap-styles announcements-container">

--- a/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -22,7 +22,7 @@
 
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-12 no-col-padding">
                 <h4><spring:message code="error.header"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/errorPermission.jsp
+++ b/src/main/webapp/WEB-INF/jsp/errorPermission.jsp
@@ -20,7 +20,6 @@
 --%>
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
     <div class="container-fluid bootstrap-styles announcements-container">

--- a/src/main/webapp/WEB-INF/jsp/errorPermission.jsp
+++ b/src/main/webapp/WEB-INF/jsp/errorPermission.jsp
@@ -22,7 +22,7 @@
 
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-12 no-col-padding">
                 <h4><spring:message code="errorPermission.unauthorized"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -20,7 +20,6 @@
 --%>
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <div>

--- a/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <c:if test="${portletPreferencesValues['includeJQuery'][0] != 'false'}">

--- a/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
+++ b/src/main/webapp/WEB-INF/jsp/previewAnnouncement.jsp
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="<rs:resourceURL value="/rs/jquery/1.11.0/jquery-1.11.0.min.js"/>"></script>
 </c:if>
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
                 <h4 role="heading"><spring:message code="preview.header"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -25,7 +25,7 @@
 
 <div id="${n}">
 
-    <div class="container-fluid bootstrap-styles announcements-container">
+    <div class="container-fluid announcements-container">
         <div class="row announcements-portlet-toolbar">
             <div class="col-md-6 no-col-padding">
                 <h4 class="title" role="heading"><spring:message code="showHistory.history"/></h4>

--- a/src/main/webapp/WEB-INF/jsp/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showHistory.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <div id="${n}">

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 
-<link rel="stylesheet" href="<rs:resourceURL value='/rs/bootstrap-namespaced/3.1.1/css/bootstrap.min.css'/>" type="text/css"/>
 <link href="<c:url value='/css/announcements.css'/>" rel="stylesheet" type="text/css"/>
 
 <c:if test="${portletPreferencesValues['includeJQuery'][0] != 'false'}">

--- a/src/main/webapp/WEB-INF/jsp/showTopic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/showTopic.jsp
@@ -79,7 +79,7 @@
     }
     </script>
 
-<div class="container-fluid bootstrap-styles announcements-container">
+<div class="container-fluid announcements-container">
     <div class="row announcements-portlet-toolbar">
         <div class="col-md-6 no-col-padding">
             <h4 class="title" role="heading"><spring:message code="show.annfor"/> <c:out value="${topic.title}"/></h4>


### PR DESCRIPTION
There have been conflicts occuring between customized upstream Bootstrap and this scoped Bootstrap.
The issue stems from the upstream bootstrap being customized, and having colors changes that should be applied to ensure WCAG 2.0 AA contrast requirements.
However those styles are being overridden by the scoped stylesheet.
This removes the conflict, by removing the scoped css and leveraging the stylesheet provided by uPortal.