### PR TITLE
docs: Added blurb regarding attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This is a [Sponsored Portlet][] in the uPortal project.
 
 See also documentation in the [AnnouncementsPortlet wiki on Confluence][].
 
+### Attachments
+See [docs/attachments.md](https://github.com/Jasig/SimpleContentPortlet/blob/HEAD/docs/attachments.md) of the [Simple Content Portlet](https://github.com/Jasig/SimpleContentPortlet) for information regarding attachments.
+
 ### Using Encrypted Property Values
 
 You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format. Use the [Jasypt CLI Tools][] to encrypt the sensitive value, then include it in a `.properties` file like this:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Contingent on jasig/SimpleContentPortlet#47. 

This change adds a blurb referring the user to the documentation housed in the [Simple Content Portlet](https://github.com/jasig/SimpleContentPortlet) repo.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
