### PR TITLE
fix(RSS Feed): Set generic description when topic doesn't have one

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
+++ b/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
@@ -196,7 +196,14 @@ public class RssFeedController {
         rslt.setFeedType("rss_2.0");
         rslt.setTitle(topic.getTitle());
         rslt.setLink(request.getRequestURL().append("?topic=").append(topic.getId()).toString());
-        rslt.setDescription(topic.getDescription());
+
+        String feedDescription = String.format("RSS feed for " + topic.getTitle());
+
+        if(!topic.getDescription().isEmpty()) {
+            feedDescription = topic.getDescription();
+        }
+
+        rslt.setDescription(feedDescription);
 
         final List<SyndEntry> entries = new ArrayList<>();
         for (Announcement a : announcements) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This change sets a generic description when topic doesn't have one

fixes #80 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl