### PR TITLE
fix(91): Remove ja-sig.org/maven2 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,14 +78,6 @@
         <tag>Announcements-2.2.0</tag>
     </scm>
 
-    <repositories>
-        <repository>
-            <id>jasig-repository</id>
-            <name>JA-SIG Maven2 Repository</name>
-            <url>http://developer.ja-sig.org/maven2</url>
-        </repository>
-    </repositories>
-
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
Resolves #91.

Testing by removing the stanza from `pom.xml`, deleting my ~/.m2/repository directory, and rebuilding. Rebuilt fine.