### PR TITLE
chore: bump uportal-portlet-parent 46 → 47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>46</version>
+        <version>47</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -35,24 +35,16 @@
     <version>2.5.1-SNAPSHOT</version>
 
     <properties>
-        <junit.version>4.13.2</junit.version>
-        <logback.version>1.3.12</logback.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hsqldb.version>2.7.0</hsqldb.version>
         <persistence-api.version>2.2</persistence-api.version>
         <resource-server.version>1.5.2</resource-server.version>
-        <servlet-api.version>3.1.0</servlet-api.version>
-        <slf4j.version>2.0.17</slf4j.version>
         <spring.version>4.3.30.RELEASE</spring.version>
 
         <!-- The JDBC Driver used by the portlet -->
         <jdbc.groupId>org.hsqldb</jdbc.groupId>
         <jdbc.artifactId>hsqldb</jdbc.artifactId>
         <jdbc.version>2.7.4</jdbc.version>
-
-        <!-- Utility libraries -->
-        <jackson.version>2.18.6</jackson.version>
-        <lombok.version>1.18.46</lombok.version>
     </properties>
 
     <url>http://www.ja-sig.org/wiki/display/PLT/Announcements+Portlet</url>
@@ -92,7 +84,6 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
         <dependency>
@@ -110,17 +101,11 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.1.2</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
-            <version>1.1.2</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -222,32 +207,26 @@
             <version>3.1</version>
         </dependency>
 
-	<dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -280,17 +259,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
         </dependency>
 
         <dependency>
@@ -361,15 +333,12 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
-            <type>jar</type>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.portlet</groupId>
             <artifactId>portlet-api</artifactId>
-            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -378,7 +347,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -477,32 +445,6 @@
                         <tag>DYNASCRIPT_STYLE</tag>
                         <less>DOUBLESLASH_STYLE</less>
                     </mapping>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.13.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-api</artifactId>
-                        <version>1.13.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                 </configuration>
             </plugin>
 
@@ -650,7 +592,7 @@
                     <dependency>
                         <groupId>javax.servlet</groupId>
                         <artifactId>javax.servlet-api</artifactId>
-                        <version>${servlet-api.version}</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>javax.portlet</groupId>


### PR DESCRIPTION
## Summary

Parent v47 promoted common deps to its `<dependencyManagement>` and caught up on slf4j / logback / maven plugin versions. This PR drops the now-redundant per-project pins.

- Drop properties: `junit.version`, `logback.version`, `slf4j.version`, `servlet-api.version`, `jackson.version`, `lombok.version` (Lombok wasn't actually used here).
- Drop `<version>` from: `javax.annotation-api`, `jstl`, `taglibs:standard`, `slf4j-*`, `logback-classic`, `jackson-core`, `jackson-databind`, `javax.servlet-api`, `portlet-api`, `junit`. All inherited from parent dM now.
- Drop the local `maven-release-plugin` and `maven-compiler-plugin` overrides — parent pluginManagement now provides 3.1.1 and 3.13.0 respectively.
- `maven-antrun-plugin`'s internal `<dependencies>` keeps an explicit `3.1.0` pin for `javax.servlet-api` (plugin-scoped deps don't inherit from project dM).

## Test plan

- [x] `mvn validate` passes (both enforcer rules green)
- [x] `mvn test` passes locally on Java 11 (5 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)