### PR TITLE
chore: pin renovate constraints + drop redundant maven-javadoc-plugin override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,22 +652,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,42 @@
 {
   "extends": ["config:base", ":rebaseStalePrs", ":preserveSemverRanges"],
-  "renovateFork": true
+  "renovateFork": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["javax.portlet:portlet-api"],
+      "allowedVersions": "< 3.0",
+      "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
+    },
+    {
+      "matchPackageNames": [
+        "org.springframework:spring-framework-bom",
+        "org.springframework:spring-beans",
+        "org.springframework:spring-core",
+        "org.springframework:spring-web",
+        "org.springframework:spring-webmvc",
+        "org.springframework:spring-webmvc-portlet",
+        "org.springframework:spring-tx",
+        "org.springframework:spring-test",
+        "org.springframework:spring-context-support",
+        "org.springframework.data:spring-data-jpa"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "This portlet is pinned to Spring Framework 4.3.x. Spring 5+ bumps require a coordinated migration."
+    },
+    {
+      "matchPackageNames": [
+        "org.hibernate:hibernate-core",
+        "org.hibernate:hibernate-ehcache",
+        "org.hibernate:hibernate-tools",
+        "org.hibernate.orm:hibernate-core"
+      ],
+      "allowedVersions": "< 6.0",
+      "description": "Pinned to Hibernate 5.6.x. Hibernate 6+ requires Jakarta EE (incompatible with javax.servlet) and Java 17+."
+    },
+    {
+      "matchPackageNames": ["org.jasig.portlet.notification:notification-portlet-api"],
+      "enabled": false,
+      "description": "Notification API v4 requires migrating off Jackson 1.x (org.codehaus.jackson) in RssFeedController. Re-enable once that migration lands."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Two cleanups that together dispose of 8 stale/rejected Renovate+Dependabot PRs.

### renovate.json — pin constraints
Add `packageRules` so Renovate stops regenerating PRs that violate this portlet's version pins.

| Rule | Why |
|---|---|
| `javax.portlet:portlet-api < 3.0` | JSR-286 only; v3 is JSR-362 (incompatible container contract) |
| `spring-*`, `spring-data-jpa < 5.0` | Portlet runs Spring 4.3.x; 5+ requires coordinated migration |
| `hibernate-*`, `hibernate.orm < 6.0` | Pinned to 5.6.15. Hibernate 6+ needs Jakarta EE + Java 17+ |
| `notification-portlet-api` disabled | v4 requires Jackson 1.x → Jackson 2.x migration in `RssFeedController.java` — re-enable once that lands |

**Closes** #246 (portlet v3), #205 (spring-bom v7), #204 (hibernate v7), #313 (hibernate-orm v7 coord change), #294/#293/#292 (3-year-old Dependabot spring 5.2/6.0 bumps).

**Pauses** #190 until the companion Jackson migration PR merges.

### pom.xml — drop redundant maven-javadoc-plugin
Parent v48 pluginManagement now binds `maven-javadoc-plugin:3.11.2` with an identical `attach-javadocs` execution. The local override at 3.4.1 was duplicating parent config and lagging behind on version.

**Supersedes** #321 (which was bumping the now-deleted block).

## Test plan
- [x] `mvn validate` passes
- [x] `mvn help:effective-pom` confirms `maven-javadoc-plugin:3.11.2` inherits from parent with the `attach-javadocs` execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)