### PR TITLE
refactor: migrate RssFeedController to Jackson 2.x API

### DIFF
--- a/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
+++ b/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
@@ -40,8 +40,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jasig.portlet.announcements.model.Announcement;
 import org.jasig.portlet.announcements.model.Topic;
 import org.jasig.portlet.announcements.mvc.portlet.display.AnnouncementsViewController;
@@ -252,11 +252,11 @@ public class RssFeedController {
                 for (String attachment : attachments) {
                     final JsonNode json = objectMapper.readTree(attachment);
                     final SyndEnclosure se = new SyndEnclosureImpl();
-                    final String enclosureUrl = urlPrefix + json.get(PATH_ATTRIBUTE).getTextValue();
+                    final String enclosureUrl = urlPrefix + json.get(PATH_ATTRIBUTE).textValue();
                     se.setUrl(enclosureUrl);
                     se.setType(
                             fileTypeMap.getContentType(
-                                    json.get(FILENAME_ATTRIBUTE).getTextValue()));
+                                    json.get(FILENAME_ATTRIBUTE).textValue()));
                     enclosures.add(se);
                 }
                 entry.setEnclosures(enclosures);


### PR DESCRIPTION
## Summary

`RssFeedController` was the last holdout in this codebase using the legacy Jackson 1.x API (`org.codehaus.jackson.*`). The old API was only on the classpath transitively via `notification-portlet-api:2.1.2`; since v3+ of that artifact drops Jackson 1.x, we need to migrate off it before bumping `notification-portlet-api` (#190).

### Changes

| Before | After |
|---|---|
| `import org.codehaus.jackson.JsonNode` | `import com.fasterxml.jackson.databind.JsonNode` |
| `import org.codehaus.jackson.map.ObjectMapper` | `import com.fasterxml.jackson.databind.ObjectMapper` |
| `JsonNode.getTextValue()` | `JsonNode.textValue()` |

`.textValue()` is the strict drop-in replacement — both Jackson 1.x's `getTextValue()` and Jackson 2.x's `textValue()` return the string value if the node is a `TextNode`, otherwise `null`. (`.asText()` would have been a subtle behavior change because it coerces non-string nodes.)

`jackson-core` + `jackson-databind` are already in this portlet's `<dependencies>` (versions inherited from parent v48's `jackson-bom` at 2.18.6), so no pom.xml change needed.

### Unblocks

Once this lands, the companion PR #331 can flip the `notification-portlet-api` renovate rule back on (currently disabled), and #190 (notification-portlet-api 2.1.2 → 4.8.0) should pass CI.

## Test plan
- [x] `mvn compile` passes on Java 11
- [ ] CI confirms on merge
- [ ] Post-merge: re-enable notification-portlet-api in renovate.json, observe #190 rebase & pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)