### PR TITLE
chore: re-enable notification-portlet-api in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,11 +32,6 @@
       ],
       "allowedVersions": "< 6.0",
       "description": "Pinned to Hibernate 5.6.x. Hibernate 6+ requires Jakarta EE (incompatible with javax.servlet) and Java 17+."
-    },
-    {
-      "matchPackageNames": ["org.jasig.portlet.notification:notification-portlet-api"],
-      "enabled": false,
-      "description": "Notification API v4 requires migrating off Jackson 1.x (org.codehaus.jackson) in RssFeedController. Re-enable once that migration lands."
     }
   ]
 }


### PR DESCRIPTION
## Summary

The Jackson 1.x → 2.x migration landed in #333, so the blocker that prompted the `enabled: false` rule in #331 is gone. Dropping the rule lets Renovate rebase #190 (notification-portlet-api 2.1.2 → 4.8.0) and retry CI.

## Follow-up

Once this merges and Renovate rebases #190, it should go green and be mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)