### PR TITLE
chore: bump parent to v49 and inherit license-plugin defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>48</version>
+        <version>49</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -393,26 +393,22 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <basedir>${basedir}</basedir>
-                    <header>${jasig-short-license-url}</header>
-                    <aggregate>true</aggregate>
+                    <!--
+                      | Parent v49 provides version, header URL, basedir,
+                      | aggregate, strictCheck, and the standard excludes/
+                      | mappings (.gitignore, .idea/**, overlays/**, LICENSE,
+                      | NOTICE, **/src/main/webapp/rs/**, target/**,
+                      | release.properties, plus tld/tag/xjb/etc mappings).
+                      | Local block keeps only the AnnouncementsPortlet-
+                      | specific webapp asset excludes; <less> mapping drops
+                      | so we inherit parent's SLASHSTAR_STYLE.
+                    +-->
                     <excludes>
-                        <exclude>.gitignore</exclude>
-                        <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
-                        <exclude>overlays/**</exclude>  <!-- for intelliJ Idea -->
-                        <exclude>LICENSE</exclude>
-                        <exclude>NOTICE</exclude>
                         <exclude>**/src/main/webapp/js/**</exclude>
-                        <exclude>**/src/main/webapp/rs/**</exclude>
                         <exclude>**/src/main/webapp/date-picker/**</exclude>
                         <exclude>**/src/main/webapp/tinymce/**</exclude>
                         <exclude>**/src/main/webapp/fonts/**</exclude>
                     </excludes>
-                    <mapping>
-                        <tld>XML_STYLE</tld>
-                        <tag>DYNASCRIPT_STYLE</tag>
-                        <less>DOUBLESLASH_STYLE</less>
-                    </mapping>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/jasig/portlet/announcements/dao/jpa/AnnouncementsRepository.java
+++ b/src/main/java/org/jasig/portlet/announcements/dao/jpa/AnnouncementsRepository.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jasig.portlet.announcements.dao.jpa;
 
 import org.jasig.portlet.announcements.model.Announcement;

--- a/src/main/java/org/jasig/portlet/announcements/dao/jpa/TopicSubscriptionsRepository.java
+++ b/src/main/java/org/jasig/portlet/announcements/dao/jpa/TopicSubscriptionsRepository.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jasig.portlet.announcements.dao.jpa;
 
 import org.jasig.portlet.announcements.model.TopicSubscription;

--- a/src/main/java/org/jasig/portlet/announcements/dao/jpa/TopicsRepository.java
+++ b/src/main/java/org/jasig/portlet/announcements/dao/jpa/TopicsRepository.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jasig.portlet.announcements.dao.jpa;
 
 import org.jasig.portlet.announcements.model.Topic;

--- a/src/main/resources/context/databaseContext.xml
+++ b/src/main/resources/context/databaseContext.xml
@@ -17,6 +17,7 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/webapp/less/announcements.less
+++ b/src/main/webapp/less/announcements.less
@@ -1,41 +1,21 @@
-//
-// Licensed to Apereo under one or more contributor license
-// agreements. See the NOTICE file distributed with this work
-// for additional information regarding copyright ownership.
-// Apereo licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file
-// except in compliance with the License.  You may obtain a
-// copy of the License at the following location:
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-//
-
-/**
- * Licensed to Jasig under one or more contributor license
+/*
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a
- * copy of the License at:
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
-
 @import "includes/_variables";
 @import "includes/_mixins.less";
 @import "includes/_base.less";

--- a/src/main/webapp/less/includes/_base.less
+++ b/src/main/webapp/less/includes/_base.less
@@ -1,41 +1,21 @@
-//
-// Licensed to Apereo under one or more contributor license
-// agreements. See the NOTICE file distributed with this work
-// for additional information regarding copyright ownership.
-// Apereo licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file
-// except in compliance with the License.  You may obtain a
-// copy of the License at the following location:
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-//
-
-/**
- * Licensed to Jasig under one or more contributor license
+/*
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a
- * copy of the License at:
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
-
 //@import "_variables.less";
 
 .announcements-container {

--- a/src/main/webapp/less/includes/_mixins.less
+++ b/src/main/webapp/less/includes/_mixins.less
@@ -1,22 +1,21 @@
-//
-// Licensed to Apereo under one or more contributor license
-// agreements. See the NOTICE file distributed with this work
-// for additional information regarding copyright ownership.
-// Apereo licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file
-// except in compliance with the License.  You may obtain a
-// copy of the License at the following location:
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-//
-
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /*---------------------------------------------------
     LESS Elements 0.9
   ---------------------------------------------------

--- a/src/main/webapp/less/includes/_variables.less
+++ b/src/main/webapp/less/includes/_variables.less
@@ -1,41 +1,21 @@
-//
-// Licensed to Apereo under one or more contributor license
-// agreements. See the NOTICE file distributed with this work
-// for additional information regarding copyright ownership.
-// Apereo licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file
-// except in compliance with the License.  You may obtain a
-// copy of the License at the following location:
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-//
-
-/**
- * Licensed to Jasig under one or more contributor license
+/*
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a
- * copy of the License at:
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
-
 /* Color Variables */
 @white: #fff;
 @black: #000;


### PR DESCRIPTION
## Summary

Bumps to the new parent v49 ([release notes](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-49)) and shrinks the local `license-maven-plugin` config to only the AnnouncementsPortlet-specific webapp asset excludes. Drops the local `<less>DOUBLESLASH_STYLE</less>` mapping override and lets `mvn license:format` normalize the .less file headers to the project-standard SLASHSTAR style.

## Why

Parent v49 promoted six of the boilerplate `<exclude>` patterns we were redundantly carrying (`.gitignore`, `.idea/**`, `overlays/**`, `LICENSE`, `NOTICE`, `**/src/main/webapp/rs/**`). Same fold-back also adds `target/**` and `release.properties`. With those gone from the local block, what's left is just the truly-local web asset excludes.

The `<less>` mapping override (`DOUBLESLASH_STYLE`) was the only LESS-comment-style outlier in the fleet outside CoursesPortlet (which was just brought in line in [CoursesPortlet#105](https://github.com/uPortal-Project/CoursesPortlet/pull/105)). Aligning to parent's `SLASHSTAR_STYLE` is the standardization the v49 release was scoped around.

## Changes

**`pom.xml`**
- Parent: `48` → `49`.
- `license-maven-plugin` `<configuration>`: drop `<basedir>`, `<header>`, `<aggregate>`, the 6 parent-provided excludes, and the `<tld>` / `<tag>` / `<less>` mapping overrides. Keep only the four AnnouncementsPortlet-specific webapp asset excludes (`js/**`, `date-picker/**`, `tinymce/**`, `fonts/**`).

**Source re-headering** (via `mvn license:format`)
- **4 `.less` files** (`announcements.less`, `includes/_base.less`, `includes/_mixins.less`, `includes/_variables.less`) — switched DOUBLESLASH (`// ...`) to SLASHSTAR (`/* ... */`) to match parent v49 default.
- **3 Java repository classes** — header content refreshed to the canonical Apereo short-license-header wording.
- **`databaseContext.xml`** — trailing blank line added inside the existing license comment (cosmetic, license:format normalization).

**Hand-stripped leftover headers**
The .less files originally carried *two* license headers each — a recent Apereo `// ...` (DOUBLESLASH) on top, and a pre-Apereo Jasig `/** ... */` (JAVADOC) below. license:format prepended the new SLASHSTAR Apereo header but doesn't recognize the older variants as license headers under strict check, so each file ended up with three stacked headers. Stripped both leftover blocks via a Python pass.

After: `grep -rl \"Licensed to Jasig\" src` returns 0 hits.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green
- [x] No remaining \"Licensed to Jasig\" in src/
- [ ] CI on the Java 11 matrix
- [ ] After merge: re-verify `mvn license:check` on master
