### PR TITLE
chore: bump parent v49 → v50 for plexus-archiver CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>49</version>
+        <version>50</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -143,6 +143,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jasig/portlet/announcements/Importer.java
+++ b/src/main/java/org/jasig/portlet/announcements/Importer.java
@@ -30,7 +30,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.HibernateException;

--- a/src/main/java/org/jasig/portlet/announcements/mvc/portlet/display/AnnouncementConfigurationController.java
+++ b/src/main/java/org/jasig/portlet/announcements/mvc/portlet/display/AnnouncementConfigurationController.java
@@ -23,7 +23,7 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletModeException;
 import javax.portlet.PortletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.announcements.model.AnnouncementConfiguration;

--- a/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
+++ b/src/main/java/org/jasig/portlet/announcements/mvc/servlet/RssFeedController.java
@@ -37,7 +37,7 @@ import javax.annotation.PostConstruct;
 import javax.portlet.PortletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/org/jasig/portlet/announcements/spring/DoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/announcements/spring/DoubleCheckedCreator.java
@@ -21,7 +21,7 @@ package org.jasig.portlet.announcements.spring;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/jasig/portlet/announcements/spring/SingletonDoubleCheckedCreator.java
+++ b/src/main/java/org/jasig/portlet/announcements/spring/SingletonDoubleCheckedCreator.java
@@ -19,8 +19,8 @@
 package org.jasig.portlet.announcements.spring;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Provides a DoubleCheckedCreator impl that tracks the singleton instance internally


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:50](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-50), which patches **CVE-2023-37460** (plexus-archiver Arbitrary File Creation in AbstractUnArchiver, CVSS 8.1 HIGH) by bumping its bundled `maven-war-plugin` 3.4.0 → 3.5.1 (which carries plexus-archiver 4.10.4, patched).

Real-world risk for portlet builds is low — we use plexus-archiver to *create* WARs, not extract untrusted archives — but the parent shouldn't ship a known-vulnerable transitive by default.

## Test plan

- [x] `mvn clean install license:check -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix