### PR TITLE
chore: regenerate NOTICE for current dep set

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,137 +16,87 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
-  %systemBundle under Eclipse Public License - v 1.0
-  A Hibernate O/RM Module under GNU Lesser General Public License
+  Animal Sniffer Annotations under MIT license
   Announcements Portlet under Apache License Version 2.0
-  ant under The Apache Software License, Version 2.0
-  AntLR under BSD License
-  AOP alliance under Public Domain
+  AntLR Parser Generator under BSD License
   Apache Ant Core under The Apache Software License, Version 2.0
   Apache Ant Launcher under The Apache Software License, Version 2.0
-  Apache Commons CLI under Apache License, Version 2.0
-  Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Compress under Apache License, Version 2.0
-  Apache Commons Lang under Apache License, Version 2.0
-  Apache Commons Math under Apache License, Version 2.0
-  Apache Commons Pool under Apache License, Version 2.0
-  Apache Groovy under The Apache Software License, Version 2.0
-  Apache HttpClient under Apache License, Version 2.0
-  Apache HttpCore under Apache License, Version 2.0
-  Apache Pluto Portal Driver under The Apache Software License, Version 2.0
-  Apache Pluto Portlet Container under The Apache Software License, Version 2.0
-  Apache Tika core under Apache License, Version 2.0
-  ASM Core under Apache License, Version 2.0
-  AspectJ Runtime under Eclipse Public License - v 2.0
+  Apache Commons Lang under Apache-2.0
+  Apache FreeMarker under Apache License, Version 2.0
+  AspectJ runtime under Eclipse Public License - v 1.0
   Backport of JSR 166 under Public Domain
-  Bouncy Castle Provider under Bouncy Castle Licence
-  cglib under Apache License, Version 2.0
-  Code Generation Library under ASF 2.0
-  com.sun:tools under COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
-  Commands under Eclipse Public License - v 1.0
-  Common Eclipse Runtime under Eclipse Public License - v 1.0
+  Byte Buddy (without dependencies) under Apache License, Version 2.0
+  Checker Qual under The MIT License
+  ClassMate under Apache License, Version 2.0
   Commons DBCP under The Apache Software License, Version 2.0
-  Commons IO under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
   Commons Pool under The Apache Software License, Version 2.0
-  Core Runtime under Eclipse Public License - v 1.0
-  Data Mapper for Jackson under The Apache Software License, Version 2.0
-  dom4j under BSD License
-  Dough Lea's util.concurrent package under Public domain, Sun Microsoystems
-  Eclipse Content Mechanism under Eclipse Public License - v 1.0
-  Eclipse Jobs Mechanism under Eclipse Public License - v 1.0
-  Eclipse Preferences Mechanism under Eclipse Public License - v 1.0
   ehcache under The Apache Software License, Version 2.0
-  Ehcache Core under The Apache Software License, Version 2.0
-  Ehcache Spring Annotations - Core under Apache 2
-  Ehcache Web Filters under The Apache Software License, Version 2.0
-  Equinox Application Container under Eclipse Public License - v 1.0
-  Extension Registry Support under Eclipse Public License - v 1.0
-  freemarker under BSD-style license
+  Error Prone shaded javac under GNU General Public License, version 2, with the Classpath Exception
+  error-prone annotations under Apache 2.0
+  Extended StAX API under Dual license consisting of the CDDL v1.1 and GPL v2
+  fastinfoset under Apache License, Version 2.0
+  FindBugs-jsr305 under The Apache Software License, Version 2.0
+  Google Java Format under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
-  Hibernate Commons Annotations under GNU LESSER GENERAL PUBLIC LICENSE
-  Hibernate Core under GNU Lesser General Public License
-  Hibernate Entity Manager under GNU Lesser General Public License
+  Hibernate Commons Annotations under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-core under GNU Library General Public License v2.1 or later
+  Hibernate ORM - hibernate-ehcache under GNU Library General Public License v2.1 or later
   Hibernate Tools under GNU Lesser General Public License
   HyperSQL Database under HSQLDB License, a BSD open source license
-  Jackson under The Apache Software License, Version 2.0
+  istack common utility code runtime under CDDL 1.1 or GPL2 w/ CPE
+  J2ObjC Annotations under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
-  Jadira Usertype Core (for Joda Time, Joda Money, Libphonenum and JDK Types with Hibernate) under Apache 2
-  Jadira Usertype SPI Classes for Hibernate under Apache 2
+  Jakarta Activation under EDL 1.0
+  Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
+  Java Annotation Indexer under Apache License, Version 2.0
   Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
   Java Servlet API under CDDL + GPLv2 with classpath exception
-  Java Transaction API under Commons Development and Distribution License, Version 1.0
+  Java Transaction API under Common Development and Distribution License or GNU General Public License, Version 2 with the Classpath Exception
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   Javassist under MPL 1.1 or LGPL 2.1
   javax.annotation API under CDDL + GPLv2 with classpath exception
+  javax.persistence-api under Eclipse Public License v1.0 or Eclipse Distribution License v. 1.0
+  JAXB Runtime under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
-  jaxb-impl under Commons Development and Distribution License, Version 1.0
-  JAXB2 Basics - Runtime under BSD-Style License
-  JBoss Logging 3 under GNU Lesser General Public License, version 2.1
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  JDOM under Apache style license
-  JGroups under Apache License 2.0
-  JJWT :: API under Apache License, Version 2.0
-  JJWT :: Extensions :: Jackson under Apache License, Version 2.0
-  JJWT :: Impl under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
-  JPA 2.0 API under Sun Binary Code License
+  JBoss Logging 3 under Apache License, version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
+  JDOM under Similar to Apache License but with the acknowledgment clause removed
   jstl under Commons Development and Distribution License, Version 1.0
-  JTidy under Java HTML Tidy License
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  LDAPTIVE CORE under Apache 2 or GNU Lesser General Public License
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  NotificationPortlet - API under JA-SIG Collaborative Licence
-  OAuth Core under The Apache Software License, Version 2.0
-  OGNL - Object Graph Navigation Library under Apache License, Version 2.0
-  oro under Apache License, Version 2.0
-  Person Directory API under Apache License, Version 2.0
-  Person Directory Implementations under Apache License, Version 2.0
-  Portlet JDBC Utilities under Apache License Version 2.0
-  Project Lombok under The MIT License
-  Resource Server API under Apache License Version 2.0
-  Resource Server Content under Apache License Version 2.0
-  Resource Server Core under Apache License Version 2.0
-  Resource Server Utilities under Apache License Version 2.0
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  notification-portlet-api under The Apache License, Version 2.0
+  Old JAXB Runtime under Eclipse Distribution License - v 1.0
   rome under The Apache Software License, Version 2.0
   rome-utils under The Apache Software License, Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
-  Spring Binding under The Apache Software License, Version 2.0
   Spring Context under Apache License, Version 2.0
   Spring Context Support under Apache License, Version 2.0
   Spring Core under Apache License, Version 2.0
+  Spring Data Core under Apache License, Version 2.0
+  Spring Data JPA under Apache License, Version 2.0
   Spring Expression Language (SpEL) under Apache License, Version 2.0
   Spring JDBC under Apache License, Version 2.0
-  Spring JS under The Apache Software License, Version 2.0
-  Spring JS Resources under The Apache Software License, Version 2.0
   Spring Object/Relational Mapping under Apache License, Version 2.0
-  Spring Object/XML Marshalling under Apache License, Version 2.0
   Spring TestContext Framework under Apache License, Version 2.0
   Spring Transaction under Apache License, Version 2.0
   Spring Web under Apache License, Version 2.0
-  Spring Web Flow under The Apache Software License, Version 2.0
   Spring Web MVC under Apache License, Version 2.0
   Spring Web Portlet under Apache License, Version 2.0
-  spring-ldap-core under The Apache Software License, Version 2.0
-  spring-modules-cache under Apache License, Version 2.0
-  spring-security-core under The Apache Software License, Version 2.0
-  spring-security-web under The Apache Software License, Version 2.0
   standard under Apache License, Version 2.0
-  Stax2 API under The BSD License
-  Text under Eclipse Public License - v 1.0
-  tomcat-jdbc under Apache License, Version 2.0
-  tomcat-juli under Apache License, Version 2.0
-  Tycho org.eclipse.jdt.core dependency (Incubation) under Eclipse Public License
+  TXW2 Runtime under CDDL+GPL License
   uPortal under The Apache License, Version 2.0
-  Woodstox under The Apache License, Version 2.0
 


### PR DESCRIPTION
Pre-release hygiene. `mvn notice:check` fails against the on-disk NOTICE because the recent dep cycle (parent v51, commons-lang3 3.20.0, notification-portlet-api 4.8.2, etc.) shifted the transitive set the NOTICE reflects.

Required before `mvn release:prepare` since the `jasig-release` profile binds `notice:check` to the validate phase — without this, the release flow trips before the version bump.

## Changes

`NOTICE`: regenerated via `mvn notice:generate` (uses parent's notice-maven-plugin and the canonical `NOTICE.template` + license-mapping URLs from the `scm-base` property).

## Test plan

- [x] `mvn notice:check` — green
- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] After merge: rerun `mvn release:prepare` for 2.5.1