### PR TITLE
chore: skip 2.5.1, bump master to 2.5.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <artifactId>Announcements</artifactId>
     <packaging>war</packaging>
     <name>Announcements Portlet</name>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
 
     <properties>
         <hibernate.version>5.6.15.Final</hibernate.version>


### PR DESCRIPTION
Skips the burned 2.5.1 version. After this merges, `mvn release:prepare` defaults to releasing 2.5.2.

## Why

A 2.5.1 release was prepared earlier today — the `Announcements-2.5.1` tag is on upstream — but the artifacts never reached Maven Central. `release:perform`'s upload to the Central Portal staging API failed signature validation:

```
Failed to verify the PGP signature. Please contact support for assistance.
```

Root cause: the signing key (`2943B2A06DC3925678EA036073B71777CA7F628A`) was published on `keyserver.ubuntu.com` but not on `keys.openpgp.org`, which Central Portal queries first. Other releases earlier today (parent v51, NotificationPortlet 4.8.2) succeeded against the same key — Central Portal's keyserver lookup appears to have been intermittently caching, then stopped working for this attempt. Fix: upload the key to `keys.openpgp.org` with email confirmation, then retry the release as 2.5.2.

Same shape as the [NotificationPortlet 4.8.1 → 4.8.2 skip](https://github.com/uPortal-Project/NotificationPortlet/releases/tag/v4.8.2). The orphan `Announcements-2.5.1` tag will remain as historical record of the prepared-but-never-published attempt; the 2.5.2 release notes will document this.

## Changes

`pom.xml`: `<version>2.5.1-SNAPSHOT</>` → `<version>2.5.2-SNAPSHOT</>`.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn notice:check` — green (post-#353)
- [x] `mvn license:check` — green
- [ ] After merge: drop the failed `org.jasig.portlet:Announcements:2.5.1` deployment in Central Portal UI; ensure signing key is on `keys.openpgp.org`; rerun `mvn release:prepare && release:perform` for 2.5.2