### PR TITLE
chore: bump master to 2.5.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <artifactId>Announcements</artifactId>
     <packaging>war</packaging>
     <name>Announcements Portlet</name>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
 
     <properties>
         <hibernate.version>5.6.15.Final</hibernate.version>


### PR DESCRIPTION
## Problem

Master pom is at \`2.5.2-SNAPSHOT\`, but \`Announcements-2.5.2\` was already tagged and released to Maven Central during the 2026-05 fleet release wave. The maven-release-plugin's post-release *"prepare for next development iteration"* commit (which advances the SNAPSHOT past the just-released version) never landed on master — releases in this repo run on a release-plugin working branch and are pushed via tag, not as a master-branch merge.

Running \`mvn release:prepare\` against the current master would try to release 2.5.2 again and collide with the existing tag.

## Changes

- **\`pom.xml\`**: \`<version>\` \`2.5.2-SNAPSHOT\` → \`2.5.3-SNAPSHOT\`.

## Why now

Prep for the 2.5.3 patch release (listener removal from #356). Without this bump, the release would fail.

Same chore-bump pattern as #354 (*"chore: skip 2.5.1, bump master to 2.5.2-SNAPSHOT"*) that handled the burned-2.5.1 scenario.

## Test plan

- [x] \`mvn -B clean install\` passes locally on Java 11
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 2.5.3